### PR TITLE
Build swarm image for nanoserver

### DIFF
--- a/swarm/build.bat
+++ b/swarm/build.bat
@@ -4,5 +4,9 @@ if not exist swarm.exe (
   docker run --name swarm-builder swarm-builder swarm --version
   docker cp swarm-builder:/go/bin/swarm.exe ./swarm.exe
 )
+copy /Y swarm.exe nano\swarm.exe
 docker build -t swarm .
 docker tag swarm:latest swarm:1.2.2
+docker build --isolation=hyperv -t swarm:nano nano
+docker tag swarm:nano swarm:1.2.2-nano
+docker tag swarm:nano swarm:latest-nano

--- a/swarm/nano/Dockerfile
+++ b/swarm/nano/Dockerfile
@@ -1,0 +1,8 @@
+FROM nanoserver
+
+COPY ./swarm.exe /swarm.exe
+
+ENV SWARM_HOST :2375
+
+ENTRYPOINT ["\\swarm.exe"]
+CMD ["--help"]

--- a/swarm/push.bat
+++ b/swarm/push.bat
@@ -1,0 +1,9 @@
+docker tag swarm:1.2.2 stefanscherer/swarm-windows:1.2.2
+docker tag swarm:latest stefanscherer/swarm-windows:latest
+docker tag swarm:1.2.2-nano stefanscherer/swarm-windows:1.2.2-nano
+docker tag swarm:latest-nano stefanscherer/swarm-windows:latest-nano
+
+docker push stefanscherer/swarm-windows:1.2.2
+docker push stefanscherer/swarm-windows:latest
+docker push stefanscherer/swarm-windows:1.2.2-nano
+docker push stefanscherer/swarm-windows:latest-nano


### PR DESCRIPTION
As Windows 10 only has Hyper-V container support and Hyper-V container only support nanoserver right now I've put `swarm.exe` into a nanoserver. This PR is a work in progress.

But running the binary in that nanoserver container the swarm.exe panics:

```
docker run -it --isolation=hyperv swarm:1.2.2-nano

panic: Failed to load shell32.dll: The specified module could not be found.

goroutine 1 [running]:
syscall.(*LazyProc).mustFind(0xc082030ae0)
        c:/go/src/syscall/dll_windows.go:280 +0x6a
syscall.(*LazyProc).Addr(0xc082030ae0, 0x7ff804e68e40)
        c:/go/src/syscall/dll_windows.go:287 +0x28
syscall.CommandLineToArgv(0x1e81762, 0xc08202bdec, 0x1, 0x0, 0x0)
        c:/go/src/syscall/zsyscall_windows.go:885 +0x3c
os.init.1()
        c:/go/src/os/exec_windows.go:100 +0x4a
os.init()
        c:/go/src/os/types_windows.go:107 +0x303
fmt.init()
        c:/go/src/fmt/scan.go:1195 +0x5d
github.com/docker/swarm/vendor/github.com/docker/docker/pkg/discovery/file.init()
        C:/Go/src/github.com/docker/swarm/vendor/github.com/docker/docker/pkg/discovery/file/file.go:109 +0x42
main.init()
        C:/Go/src/github.com/docker/swarm/main.go:14 +0x42
```

The `swarm.exe` is compiled with Go 1.5.4.

cc @friism any ideas?