### PR TITLE
Create openssl docker image

### DIFF
--- a/openssl/Dockerfile
+++ b/openssl/Dockerfile
@@ -1,0 +1,14 @@
+FROM microsoft/windowsservercore
+MAINTAINER scherer_stefan@icloud.com
+
+ENV chocolateyUseWindowsCompression false
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
+    choco install -y openssl.light
+
+WORKDIR "C:\\Program Files\\OpenSSL\\bin"
+
+CMD .\openssl.exe genrsa -out /certs/$env:KEY_NAME.key 1024 ; \
+    .\openssl.exe req  -new -newkey rsa:4096 -days 365 -nodes -subj $('/C=/ST=/L=/O=/CN={0}' -f $env:COMMON_NAME) -keyout /certs/$env:KEY_NAME.key -out /certs/$env:KEY_NAME.csr ; \
+    .\openssl.exe x509 -req -days 365 -in /certs/$env:KEY_NAME.csr -signkey /certs/$env:KEY_NAME.key -out /certs/$env:KEY_NAME.crt

--- a/openssl/README.md
+++ b/openssl/README.md
@@ -1,0 +1,5 @@
+# openssl
+
+Derived from the Linux version from https://github.com/CenturyLinkLabs/openssl
+
+Usage `docker run --rm -e COMMON_NAME=<Common Name> -e KEY_NAME=<Cert File Names Prefix> -v /var/certs:/certs stefanscherer/openssl-windows`


### PR DESCRIPTION
Instead of installing OpenSSL on Windows just use a Windows container. Derived from https://github.com/CenturyLinkLabs/openssl

Example:

```
docker run --rm -e COMMON_NAME=commonname -e KEY_NAME=certprefix -v "$(pwd)\certs:c:\certs" stefanscherer/openssl-windows
```
