### PR TITLE
Create Docker TLS certs in Docker

### DIFF
--- a/dockertls/Dockerfile
+++ b/dockertls/Dockerfile
@@ -1,0 +1,16 @@
+FROM stefanscherer/openssl-windows
+MAINTAINER scherer_stefan@icloud.com
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+RUN Invoke-WebRequest -Uri https://github.com/Microsoft/Virtualization-Documentation/raw/master/windows-server-container-tools/DockerTLS/DockerCertificateTools.ps1 -OutFile DockerCertificateTools.ps1
+
+CMD . .\DockerCertificateTools.ps1 ; \
+    New-OpenSSLCertAuth ; \
+    New-ClientKeyandCert ; \
+    New-ServerKeyandCert -serverName $('{0}' -f $env:SERVER_NAME) -serverIPAddresses @( $($env:IP_ADDRESSES).Split(' ')) ; \
+    Copy C:\MyDockerKeys\ca-key.pem C:\certs ; \
+    Copy C:\MyDockerKeys\ca.pem C:\certs ; \
+    Copy C:\MyDockerKeys\cert.pem C:\certs ; \
+    Copy C:\MyDockerKeys\$($env:SERVER_NAME)_server-cert.pem C:\certs\server-cert.pem ; \
+    Copy C:\MyDockerKeys\$($env:SERVER_NAME)_server-key.pem C:\certs\server-key.pem

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -1,0 +1,28 @@
+# dockertls
+
+Create TLS certs for Docker, inside a Docker container. This avoids installin OpenSSL directly on your machine.
+The script https://github.com/Microsoft/Virtualization-Documentation/blob/master/windows-server-container-tools/DockerTLS/DockerCertificateTools.ps1 will be used to create the certs.
+
+## Usage
+
+```
+mkdir certs
+docker run -e SERVER_NAME=$(hostname) -e IP_ADDRESSES="192.168.254.135 127.0.0.1" -v "$(pwd)\certs:c:\certs" dockertls
+dir certs
+
+    Directory: C:\Users\demo\certs
+
+Mode                LastWriteTime         Length Name
+----                -------------         ------ ----
+-a----       10/19/2016   2:26 PM           3380 ca-key.pem
+-a----       10/19/2016   2:26 PM           1976 ca.pem
+-a----       10/19/2016   2:26 PM           1810 cert.pem
+-a----       10/19/2016   2:26 PM           1822 server-cert.pem
+-a----       10/19/2016   2:26 PM           3294 server-key.pem
+```
+
+
+## See also
+
+* https://docs.docker.com/engine/security/https/
+* https://github.com/Microsoft/Virtualization-Documentation/tree/master/windows-server-container-tools/DockerTLS


### PR DESCRIPTION
Just a small fun Dockerfile to run the https://github.com/Microsoft/Virtualization-Documentation/tree/master/windows-server-container-tools/DockerTLS script on a Win2016 machine, but without installing OpenSSL directly on that machine. 

```
PS C:\> mkdir certs
PS C:\> docker run -e SERVER_NAME=$(hostname) -e IP_ADDRESSES="192.168.254.135 127.0.0.1" -v "$(pwd)\certs:c:\certs" stefanscherer/dockertls-windows
Creating Certificate Authority Keys
-Creating CA private key
-Creating CA public key
-Certificate Authority Keys Generated
Creating Client Key and Certifcate
-Verifying CA Keys
-Creating client key
-Creating cient certificate request
-Creating extended key use extention file
-Signing client request and generating certificate
-Creating PFX file for Windows
-Clening up extention file and cerficate request file
-Done Creating Client Certifcates!
Creating Server Key and Certifcate
-Verifying CA Keys
-Creating Server key
-Creating Server certificate request
-Creating extended key use extention file
-Signing Server request and generating certificate
-Cleaning up extention file and cerficate request file
-Done Creating Server Certifcates!
PS C:\> dir certs

    Directory: C:\Users\demo\certs

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----       10/19/2016   2:26 PM           3380 ca-key.pem
-a----       10/19/2016   2:26 PM           1976 ca.pem
-a----       10/19/2016   2:26 PM           1810 cert.pem
-a----       10/19/2016   2:26 PM           1822 server-cert.pem
-a----       10/19/2016   2:26 PM           3294 server-key.pem
```
