### PR TITLE
Improve dockertls to create daemon.json and copy certs to server and user's dir

### DIFF
--- a/dockertls/.gitignore
+++ b/dockertls/.gitignore
@@ -1,0 +1,2 @@
+client/
+server/

--- a/dockertls/Dockerfile
+++ b/dockertls/Dockerfile
@@ -1,16 +1,14 @@
-FROM stefanscherer/openssl-windows
+FROM microsoft/windowsservercore
 MAINTAINER scherer_stefan@icloud.com
 
+ENV chocolateyUseWindowsCompression false
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-RUN Invoke-WebRequest -Uri https://github.com/Microsoft/Virtualization-Documentation/raw/master/windows-server-container-tools/DockerTLS/DockerCertificateTools.ps1 -OutFile DockerCertificateTools.ps1
+RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
+    choco install -y openssl.light; \
+    $env:PATH = 'C:\Program Files\OpenSSL\bin;' + $env:PATH; \
+  	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
-CMD . .\DockerCertificateTools.ps1 ; \
-    New-OpenSSLCertAuth ; \
-    New-ClientKeyandCert ; \
-    New-ServerKeyandCert -serverName $('{0}' -f $env:SERVER_NAME) -serverIPAddresses @( $($env:IP_ADDRESSES).Split(' ')) ; \
-    Copy C:\MyDockerKeys\ca-key.pem C:\certs ; \
-    Copy C:\MyDockerKeys\ca.pem C:\certs ; \
-    Copy C:\MyDockerKeys\cert.pem C:\certs ; \
-    Copy C:\MyDockerKeys\$($env:SERVER_NAME)_server-cert.pem C:\certs\server-cert.pem ; \
-    Copy C:\MyDockerKeys\$($env:SERVER_NAME)_server-key.pem C:\certs\server-key.pem
+COPY generate-certs.ps1 generate-certs.ps1
+
+CMD . .\generate-certs.ps1

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -5,14 +5,14 @@ The script https://github.com/Microsoft/Virtualization-Documentation/blob/master
 
 ## Usage
 
-## Test drive
+### Test drive
 
 Just run it in a clean environment creating two folders on your host:
 
 ```
 mkdir server
 mkdir client\.docker
-docker run `
+docker run --rm `
   -e SERVER_NAME=$(hostname) `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
   -v "$(pwd)\server:c:\programdata\docker" `
@@ -22,6 +22,22 @@ dir server\config
 dir client\.docker
 ```
 
+### Create your certs
+
+Now create the certs and let the container
+
+1. copy the Server certs into Docker service config folder
+2. create or update the Docker service config file `daemon.json`
+3. copy the Client certs into your home directory.
+
+```
+mkdir $env:USERPROFILE\.docker
+docker run --rm `
+  -e SERVER_NAME=$(hostname) `
+  -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
+  -v "$(pwd)\programdata\docker:c:\programdata\docker" `
+  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" dockertls
+```
 
 ## See also
 

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -5,20 +5,21 @@ The script https://github.com/Microsoft/Virtualization-Documentation/blob/master
 
 ## Usage
 
+## Test drive
+
+Just run it in a clean environment creating two folders on your host:
+
 ```
-mkdir certs
-docker run -e SERVER_NAME=$(hostname) -e IP_ADDRESSES="192.168.254.135 127.0.0.1" -v "$(pwd)\certs:c:\certs" dockertls
-dir certs
-
-    Directory: C:\Users\demo\certs
-
-Mode                LastWriteTime         Length Name
-----                -------------         ------ ----
--a----       10/19/2016   2:26 PM           3380 ca-key.pem
--a----       10/19/2016   2:26 PM           1976 ca.pem
--a----       10/19/2016   2:26 PM           1810 cert.pem
--a----       10/19/2016   2:26 PM           1822 server-cert.pem
--a----       10/19/2016   2:26 PM           3294 server-key.pem
+mkdir server
+mkdir client\.docker
+docker run `
+  -e SERVER_NAME=$(hostname) `
+  -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
+  -v "$(pwd)\server:c:\programdata\docker" `
+  -v "$(pwd)\client\.docker:c:\users\containeradministrator\.docker" dockertls
+dir server\certs.d
+dir server\config
+dir client\.docker
 ```
 
 

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -39,6 +39,30 @@ docker run --rm `
   -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" dockertls
 ```
 
+Afterwards restart the Docker service in an administrator SHELL
+
+```
+restart-service docker
+```
+
+Now connect to the TLS secured Docker service with
+
+```
+docker --tlsverify `
+  --tlscacert=$env:USERPROFILE\.docker\ca.pem `
+  --tlscert=$env:USERPROFILE\.docker\cert.pem `
+  --tlskey=$env:USERPROFILE\.docker\key.pem `
+  -H=tcp://127.0.0.1:2376 version
+```
+
+Or just set some environment variables
+
+```
+$env:DOCKER_HOST="tcp://127.0.0.1:2376"
+$env:DOCKER_TLS_VERIFY="1"
+docker version
+```
+
 ## See also
 
 * https://docs.docker.com/engine/security/https/

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -35,7 +35,7 @@ mkdir $env:USERPROFILE\.docker
 docker run --rm `
   -e SERVER_NAME=$(hostname) `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
-  -v "$(pwd)\programdata\docker:c:\programdata\docker" `
+  -v "c:\programdata\docker:c:\programdata\docker" `
   -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" dockertls
 ```
 

--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -1,0 +1,25 @@
+$ErrorActionPreference = "Stop"
+
+function createCerts($certsPath) {
+  Write-Host "TODO"
+}
+
+function updateConfig($daemonJson, $certsPath) {
+  $config = @{}
+  if (Test-Path $daemonJson) {
+    $config = (Get-Content $daemonJson) -join "`n" | ConvertFrom-Json
+  }
+
+  $config = $config | Add-Member(@{ `
+    hosts = @("tcp://0.0.0.0:2376", "npipe://"); `
+    tlsverify = $true; `
+    tlscacert = "$certsPath\ca.pem"; `
+    tlscert = "$certsPath\server-cert.pem"; `
+    tlskey = "$certsPath\server-key.pem" `
+    }) -Force -PassThru
+
+  $config | ConvertTo-Json | Set-Content $daemonJson -Encoding Ascii
+}
+
+createCerts "C:\ProgramData\docker\certs.d"
+updateConfig "C:\ProgramData\docker\config\daemon.json" "C:\ProgramData\docker\certs.d"

--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -1,7 +1,55 @@
 $ErrorActionPreference = "Stop"
 
-function createCerts($certsPath) {
-  Write-Host "TODO"
+function ensureDirs($dirs) {
+  foreach ($dir in $dirs) {
+    if (!(Test-Path $dir)) {
+      mkdir $dir
+    }
+  }
+}
+
+# https://docs.docker.com/engine/security/https/
+function createCerts($certsPath, $serverName, $ipAddresses) {
+  $caPass = "pass:$(openssl rand -base64 32)"
+
+  Write-Host "`n=== Generating CA private key"
+  & openssl genrsa -aes256 -passout $caPass -out ca-key.pem 4096
+
+  Write-Host "`n=== Generating CA public key"
+  & openssl req -subj "/C=US/ST=Washington/L=Redmond/O=./OU=." -new -x509 -days 365 -passin $caPass -key ca-key.pem -sha256 -out ca.pem
+
+  Write-Host "`n=== Generating CA private key"
+  & openssl genrsa -out server-key.pem 4096
+
+  Write-Host "`n=== Generating Server signing request"
+  & openssl req -subj "/CN=$serverName/" -sha256 -new -key server-key.pem -out server.csr
+
+  Write-Host "`n=== Signing Server request"
+  "subjectAltName = " + (($ipAddresses.Split(' ') | ForEach-Object { "IP:$_" }) -join ',') | Out-File extfile.cnf -Encoding Ascii
+  cat extfile.cnf
+  & openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -passin $caPass -CAkey ca-key.pem `
+    -CAcreateserial -out server-cert.pem -extfile extfile.cnf
+
+  Write-Host "`n=== Generating Client key"
+  & openssl genrsa -out key.pem 4096
+
+  Write-Host "`n=== Generating Client signing request"
+  & openssl req -subj '/CN=client' -new -key key.pem -out client.csr
+
+  Write-Host "`n=== Signing Client signing request"
+  "extendedKeyUsage = clientAuth" | Out-File extfile.cnf -Encoding Ascii
+  & openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -passin $caPass -CAkey ca-key.pem `
+    -CAcreateserial -out cert.pem -extfile extfile.cnf
+
+  Write-Host "`n=== Copying Server certifcates to $certPath"
+  copy ca.pem $certsPath\ca.pem
+  copy server-cert.pem $certsPath\server-cert.pem
+  copy server-key.pem $certsPath\server-key.pem
+
+  Write-Host "`n=== Copying Client certifcates to $userPath"
+  copy ca.pem $userPath\ca.pem
+  copy cert.pem $userPath\cert.pem
+  copy key.pem $userPath\key.pem
 }
 
 function updateConfig($daemonJson, $certsPath) {
@@ -18,8 +66,19 @@ function updateConfig($daemonJson, $certsPath) {
     tlskey = "$certsPath\server-key.pem" `
     }) -Force -PassThru
 
+  Write-Host "`n=== Creating / Updating $daemonJson"
   $config | ConvertTo-Json | Set-Content $daemonJson -Encoding Ascii
 }
 
-createCerts "C:\ProgramData\docker\certs.d"
-updateConfig "C:\ProgramData\docker\config\daemon.json" "C:\ProgramData\docker\certs.d"
+$dockerData = "$env:ProgramData\docker"
+$serverName = $env:SERVER_NAME
+$ipAddresses = $env:IP_ADDRESSES
+$userPath = "$env:USERPROFILE\.docker"
+
+ensureDirs @("$dockerData\certs.d", "$dockerData\config", "$userPath")
+createCerts "$dockerData\certs.d" $serverName $ipAddresses
+updateConfig "$dockerData\config\daemon.json" "$dockerData\certs.d" "$userPath"
+
+Write-Host "`n=== Finished"
+Write-Host "Now restart Docker service with the following command:"
+Write-Host "restart-service docker"

--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -25,7 +25,7 @@ function createCerts($certsPath, $serverName, $ipAddresses) {
   & openssl req -subj "/CN=$serverName/" -sha256 -new -key server-key.pem -out server.csr
 
   Write-Host "`n=== Signing Server request"
-  "subjectAltName = " + (($ipAddresses.Split(' ') | ForEach-Object { "IP:$_" }) -join ',') | Out-File extfile.cnf -Encoding Ascii
+  "subjectAltName = " + (($ipAddresses.Split(',') | ForEach-Object { "IP:$_" }) -join ',') | Out-File extfile.cnf -Encoding Ascii
   cat extfile.cnf
   & openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -passin $caPass -CAkey ca-key.pem `
     -CAcreateserial -out server-cert.pem -extfile extfile.cnf


### PR DESCRIPTION
Simplify creating Docker TLS certs with the updated Dockerfile:

```
mkdir $env:USERPROFILE\.docker
docker run --rm `
  -e SERVER_NAME=$(hostname) `
  -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
  -v "c:\programdata\docker:c:\programdata\docker" `
  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" dockertls
```
