### PR TITLE
work around some strange error while fetching tools/godep

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore
+FROM microsoft/nanoserver
 
 COPY ./registry.exe /registry.exe
 COPY config.yml /config/config.yml

--- a/registry/build.bat
+++ b/registry/build.bat
@@ -1,7 +1,7 @@
 if not exist registry.exe (
   docker build -t registry-builder build
   docker rm -f registry-builder
-  docker run --name registry-builder registry-builder /go/src/github.com/docker/distribution/registry.exe --version
+  docker create --name registry-builder registry-builder
   docker cp registry-builder:/go/src/github.com/docker/distribution/registry.exe ./registry.exe
 )
 docker build -t registry .

--- a/registry/build.bat
+++ b/registry/build.bat
@@ -1,7 +1,7 @@
 if not exist registry.exe (
   docker build -t registry-builder build
   docker rm -f registry-builder
-  docker run --name registry-builder registry-builder registry --version
+  docker run --name registry-builder registry-builder /go/src/github.com/docker/distribution/registry.exe --version
   docker cp registry-builder:/go/src/github.com/docker/distribution/registry.exe ./registry.exe
 )
 docker build -t registry .

--- a/registry/build.sh
+++ b/registry/build.sh
@@ -3,7 +3,7 @@
 if [ ! -e registry.exe ]; then
   docker build -t registry-builder build
   docker rm -f registry-builder
-  docker run --name registry-builder registry-builder registry --version
+  docker create --name registry-builder registry-builder
   docker cp registry-builder:/go/src/github.com/docker/distribution/registry.exe ./registry.exe
 fi
 docker build -t registry .

--- a/registry/build/Dockerfile
+++ b/registry/build/Dockerfile
@@ -5,10 +5,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 ENV DOCKER_BUILDTAGS include_oss include_gcs
 ENV DISTRIBUTION_VERSION v2.5.1
 
-RUN go get github.com/tools/godep ; \
-    mkdir src\github.com\docker ; \
+RUN mkdir src\github.com\docker ; \
     cd src\github.com\docker ; \
     git clone https://github.com/docker/distribution ; \
     cd distribution ; \
     git checkout $env:DISTRIBUTION_VERSION ; \
+    try { go get github.com/tools/godep } catch { } ; \
+    go get github.com/tools/godep ; \
     Start-Process -FilePath godep.exe -ArgumentList go, build, ./cmd/registry -Wait


### PR DESCRIPTION
Hey, I tried to build the Windows registry on a machine with Windows 10 installed (no VM or other virtualization in-between). I constantly got an error for the `go get github.com/tools/godep` command saying `package github.com/tools/godep: exit status 66`.
This commit works around that issue by catching the error and retrying the same command.
I'm not sure whether this is an issue for me only, but after trying several variants I assume that this workaround won't hurt ;-)
If you have other/better suggestions, please advice, thanks!
