### PR TITLE
Faster way to get BuildLabString (WinVer info)

### DIFF
--- a/PowerShellTricks.md
+++ b/PowerShellTricks.md
@@ -146,7 +146,7 @@ Surprise!
 ## Get Windows version
 
 ```powershell
-PS C:\Users\vagrant> $(gin).WindowsBuildLabEx
+PS C:\Users\vagrant> $(gp "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").BuildLabEx
 14393.447.amd64fre.rs1_release_inmarket.161102-0100
 PS C:\Users\vagrant> winver
 ```

--- a/PowerShellTricks.md
+++ b/PowerShellTricks.md
@@ -146,7 +146,7 @@ Surprise!
 ## Get Windows version
 
 ```powershell
-PS C:\Users\vagrant> $(gin).WindowsBuildLabEx
+PS C:\Users\vagrant> $(gp "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").BuildLabExildLabEx
 14393.447.amd64fre.rs1_release_inmarket.161102-0100
 PS C:\Users\vagrant> winver
 ```

--- a/PowerShellTricks.md
+++ b/PowerShellTricks.md
@@ -146,7 +146,7 @@ Surprise!
 ## Get Windows version
 
 ```powershell
-PS C:\Users\vagrant> $(gp "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").BuildLabExildLabEx
+PS C:\Users\vagrant> $(gin).WindowsBuildLabEx
 14393.447.amd64fre.rs1_release_inmarket.161102-0100
 PS C:\Users\vagrant> winver
 ```


### PR DESCRIPTION
C:\Users\brycem> measure-command {$(gin).WindowsBuildLabEx}

Seconds           : 42
TotalMilliseconds : 42237.3783

C:\Users\brycem> measure-command {$(gp 'HKLM:\SOFTWARE\Microsoft\Windows
NT\CurrentVersion').BuildLabEx}

Seconds           : 0
TotalMilliseconds : 15.3891