### PR TITLE
Fixed nano onbuild Dockerfile

### DIFF
--- a/node/6.9/nano/onbuild/Dockerfile
+++ b/node/6.9/nano/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.9.1
+FROM node:6.9.1-nano
 
 RUN mkdir \app
 WORKDIR /app

--- a/node/7.2/nano/onbuild/Dockerfile
+++ b/node/7.2/nano/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7.2.0
+FROM node:7.2.0-nano
 
 RUN mkdir \app
 WORKDIR /app


### PR DESCRIPTION
Change in nano onbuild dockerfiles in order du base docker image on
nanoserver nodejs image instead of windowsservercore image.

Fixes StefanScherer/dockerfiles-windows/issues/31