### PR TITLE
Feature/nodejs nano check file hash

### DIFF
--- a/node/4.6/nano/Dockerfile
+++ b/node/4.6/nano/Dockerfile
@@ -7,6 +7,7 @@ ENV NODE_VERSION 4.6.2
 ENV NODE_SHA256 f4106162d3b7827747c6da994421474e6882caf78e0f99c50572e766e82c4e06
 
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+	if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
     [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\node.zip', 'C:\') ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
     New-Item $($env:APPDATA + '\npm') ; \

--- a/node/6.9/nano/Dockerfile
+++ b/node/6.9/nano/Dockerfile
@@ -7,6 +7,7 @@ ENV NODE_VERSION 6.9.1
 ENV NODE_SHA256 e4c5a82cf481c1eb6ea7db109d70c43a0169203eae7608e2140863efc42c25ce
 
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+	if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
     [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\node.zip', 'C:\') ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
     New-Item $($env:APPDATA + '\npm') ; \

--- a/node/6.9/nano/onbuild/Dockerfile
+++ b/node/6.9/nano/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.9.1
+FROM node:6.9.1-nano
 
 RUN mkdir \app
 WORKDIR /app

--- a/node/7.2/nano/Dockerfile
+++ b/node/7.2/nano/Dockerfile
@@ -7,6 +7,7 @@ ENV NODE_VERSION 7.2.0
 ENV NODE_SHA256 887c207972cdc191953dbcfa7b4a3f13667063a9aa82e471c779247c555722d5
 
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+	if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
     [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\node.zip', 'C:\') ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
     New-Item $($env:APPDATA + '\npm') ; \

--- a/node/7.2/nano/onbuild/Dockerfile
+++ b/node/7.2/nano/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7.2.0
+FROM node:7.2.0-nano
 
 RUN mkdir \app
 WORKDIR /app


### PR DESCRIPTION
Add file hash verification for the nodejs archive when building nodejs images based on nanoserver.
fixes StefanScherer/dockerfiles-windows#32