### PR TITLE
Improve docker rmi, keeping all base images

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -8,8 +8,7 @@ docker pull microsoft/nanoserver
 
 Write-Host Removing old images
 $ErrorActionPreference = 'SilentlyContinue';
-docker rmi $(docker images --no-trunc | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))' | Foreac
-h {($_ -split '\s+',4)[0]})
+docker rmi $(docker images --no-trunc | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))' | Foreach {($_ -split '\s+',4)[0]})
 $ErrorActionPreference = 'Stop';
 Write-Host Prune system
 docker system prune -f

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,7 @@ docker pull microsoft/nanoserver
 
 Write-Host Removing old images
 $ErrorActionPreference = 'SilentlyContinue';
-docker rmi $(docker images --no-trunc --format '{{.Repository}}:{{.Tag}}' | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))' | Foreach {($_ -split '\s+',4)[0]})
+docker rmi $(docker images --no-trunc --format '{{.Repository}}:{{.Tag}}' | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))')
 $ErrorActionPreference = 'Stop';
 Write-Host Prune system
 docker system prune -f

--- a/build.ps1
+++ b/build.ps1
@@ -8,8 +8,10 @@ docker pull microsoft/nanoserver
 
 Write-Host Removing old images
 $ErrorActionPreference = 'SilentlyContinue';
-docker rmi -f $(docker images --filter "since=microsoft/nanoserver" -q)
+docker rmi $(docker images --no-trunc | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))' | Foreac
+h {($_ -split '\s+',4)[0]})
 $ErrorActionPreference = 'Stop';
+Write-Host Prune system
 docker system prune -f
 
 if ( $env:APPVEYOR_PULL_REQUEST_NUMBER ) {

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,7 @@ docker pull microsoft/nanoserver
 
 Write-Host Removing old images
 $ErrorActionPreference = 'SilentlyContinue';
-docker rmi $(docker images --no-trunc | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))' | Foreach {($_ -split '\s+',4)[0]})
+docker rmi $(docker images --no-trunc --format '{{.Repository}}:{{.Tag}}' | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))' | Foreach {($_ -split '\s+',4)[0]})
 $ErrorActionPreference = 'Stop';
 Write-Host Prune system
 docker system prune -f


### PR DESCRIPTION
`docker rmi` should keep all microsoft/windowsservercore and microsoft/nanoserver base images. 

The previous approach `docker rmi -f $(docker images --filter "since=microsoft/nanoserver" -q)` still removed the newer windowsservercore image.
