### PR TITLE
Allow for configuration of multiple hosts with the same CA

### DIFF
--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -63,6 +63,34 @@ $env:DOCKER_TLS_VERIFY="1"
 docker version
 ```
 
+## Managing Multiple Hosts
+
+## First Host
+For the first host you must create an empty directory to hold the Certificate Authority Private Keys.
+Ideally the key and password should be kept separate and only provided when additional certificates are created.
+```
+mkdir $env:SystemDrive\DockerSSLCARoot
+mkdir $env:USERPROFILE\.docker
+docker run --rm `
+  -e SERVER_NAME=$(hostname) `
+  -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
+  -v "$env:SystemDrive\DockerSSLCARoot:c:\DockerSSLCARoot" `
+  -v "$env:ALLUSERSPROFILE\docker:$env:ALLUSERSPROFILE\docker" `
+  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+```
+## Subsequent Hosts
+For subsequent hosts you first need to copy over the DockerSSLCARoot directory from the first host.
+```
+Copy-Item -Path <somesecurelocation>\DockerSSLCARoot c:\DockerSSLCARoot
+mkdir $env:USERPROFILE\.docker
+docker run --rm `
+  -e SERVER_NAME=$(hostname) `
+  -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
+  -v "$env:SystemDrive\DockerSSLCARoot:c:\DockerSSLCARoot" `
+  -v "$env:ALLUSERSPROFILE\docker:$env:ALLUSERSPROFILE\docker" `
+  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+```
+
 ## See also
 
 * [Dockerfile](https://github.com/StefanScherer/dockerfiles-windows/blob/master/dockertls/Dockerfile)

--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -1,5 +1,12 @@
 $ErrorActionPreference = "Stop"
 
+$Global:DockerSSLCARoot = "c:\DockerSSLCARoot\"
+$Global:caPrivateKeyPassFile = ($Global:DockerSSLCARoot + "ca-key-pass.txt")
+$Global:caPrivateKeyPass = ""
+$Global:caPrivateKeyFile = ($Global:DockerSSLCARoot + "ca-key.pem")
+$Global:caPublicKeyFile = ($Global:DockerSSLCARoot + "ca.pem")
+
+
 function ensureDirs($dirs) {
   foreach ($dir in $dirs) {
     if (!(Test-Path $dir)) {
@@ -9,16 +16,26 @@ function ensureDirs($dirs) {
 }
 
 # https://docs.docker.com/engine/security/https/
-function createCerts($certsPath, $serverName, $ipAddresses) {
-  $caPass = "pass:$(openssl rand -base64 32)"
+function createCA(){
+  Write-Host "`n=== Generating CA private password"
+  $Global:caPrivateKeyPass = "pass:$(openssl rand -base64 32)"
+
+  Write-Host "`n=== Writing out private key password"
+  $Global:caPrivateKeyPass | Out-File -FilePath $Global:caPrivateKeyPassFile
 
   Write-Host "`n=== Generating CA private key"
-  & openssl genrsa -aes256 -passout $caPass -out ca-key.pem 4096
+  & openssl genrsa -aes256 -passout $Global:caPrivateKeyPass -out $Global:caPrivateKeyFile 4096
 
   Write-Host "`n=== Generating CA public key"
-  & openssl req -subj "/C=US/ST=Washington/L=Redmond/O=./OU=." -new -x509 -days 365 -passin $caPass -key ca-key.pem -sha256 -out ca.pem
+  & openssl req -subj "/C=US/ST=Washington/L=Redmond/O=./OU=." -new -x509 -days 365 -passin $Global:caPrivateKeyPass -key $Global:caPrivateKeyFile -sha256 -out $Global:caPublicKeyFile
+}
 
-  Write-Host "`n=== Generating CA private key"
+# https://docs.docker.com/engine/security/https/
+function createCerts($certsPath, $serverName, $ipAddresses) {
+  Write-Host "`n=== Reading in CA Private Key Password"
+  $Global:caPrivateKeyPass = Get-Content -Path $Global:caPrivateKeyPassFile
+
+  Write-Host "`n=== Generating Server private key"
   & openssl genrsa -out server-key.pem 4096
 
   Write-Host "`n=== Generating Server signing request"
@@ -27,7 +44,7 @@ function createCerts($certsPath, $serverName, $ipAddresses) {
   Write-Host "`n=== Signing Server request"
   "subjectAltName = " + (($ipAddresses.Split(',') | ForEach-Object { "IP:$_" }) -join ',') | Out-File extfile.cnf -Encoding Ascii
   cat extfile.cnf
-  & openssl x509 -req -days 365 -sha256 -in server.csr -CA ca.pem -passin $caPass -CAkey ca-key.pem `
+  & openssl x509 -req -days 365 -sha256 -in server.csr -CA $Global:caPublicKeyFile -passin $Global:caPrivateKeyPass -CAkey $Global:caPrivateKeyFile `
     -CAcreateserial -out server-cert.pem -extfile extfile.cnf
 
   Write-Host "`n=== Generating Client key"
@@ -38,16 +55,16 @@ function createCerts($certsPath, $serverName, $ipAddresses) {
 
   Write-Host "`n=== Signing Client signing request"
   "extendedKeyUsage = clientAuth" | Out-File extfile.cnf -Encoding Ascii
-  & openssl x509 -req -days 365 -sha256 -in client.csr -CA ca.pem -passin $caPass -CAkey ca-key.pem `
+  & openssl x509 -req -days 365 -sha256 -in client.csr -CA $Global:caPublicKeyFile -passin $Global:caPrivateKeyPass -CAkey $Global:caPrivateKeyFile `
     -CAcreateserial -out cert.pem -extfile extfile.cnf
 
   Write-Host "`n=== Copying Server certifcates to $certPath"
-  copy ca.pem $certsPath\ca.pem
+  copy $Global:caPublicKeyFile $certsPath\ca.pem
   copy server-cert.pem $certsPath\server-cert.pem
   copy server-key.pem $certsPath\server-key.pem
 
   Write-Host "`n=== Copying Client certifcates to $userPath"
-  copy ca.pem $userPath\ca.pem
+  copy $Global:caPublicKeyFile $userPath\ca.pem
   copy cert.pem $userPath\cert.pem
   copy key.pem $userPath\key.pem
 }
@@ -70,12 +87,24 @@ function updateConfig($daemonJson, $certsPath) {
   $config | ConvertTo-Json | Set-Content $daemonJson -Encoding Ascii
 }
 
+
 $dockerData = "$env:ProgramData\docker"
 $serverName = $env:SERVER_NAME
 $ipAddresses = $env:IP_ADDRESSES
 $userPath = "$env:USERPROFILE\.docker"
 
-ensureDirs @("$dockerData\certs.d", "$dockerData\config", "$userPath")
+
+ensureDirs @("$dockerData\certs.d", "$dockerData\config", "$userPath", $Global:DockerSSLCARoot)
+
+#Test the CA Root path to see if an existing set of CA keys was provided
+if (  !(Test-Path -Path $Global:caPrivateKeyPassFile) -or 
+      !( Test-Path -Path $Global:caPrivateKeyFile) -or
+      !( Test-Path -Path $Global:caPrivateKeyPassFile) 
+   )
+{
+  createCA
+}
+
 createCerts "$dockerData\certs.d" $serverName $ipAddresses
 updateConfig "$dockerData\config\daemon.json" "$dockerData\certs.d" "$userPath"
 


### PR DESCRIPTION
This change enables you to use the same CA Key for multiple hosts, with the ultimate goal of using the same client certificate for multiple hosts.

The other approach that might be considered would be to separate out the three main phases into separate images.  i.e. First image=CreateCA, Second Image=CreateServerCert, Third Image=CreateClientCert.  But that was a more radical change than I wanted to do without thoughts from others.

Tested=Creating certs for two hosts w/same client and using the image with the existing parameters (i.e. unmodified)