### PR TITLE
Update golang 1.8beta2, git 2.11.0

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -3,10 +3,10 @@ FROM microsoft/windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # install Git (especially for "go get")
-ENV GIT_VERSION 2.9.2
+ENV GIT_VERSION 2.11.0
 ENV GIT_TAG v${GIT_VERSION}.windows.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/Git-${GIT_VERSION}-64-bit.exe
-ENV GIT_DOWNLOAD_SHA256 006d971bcbe73cc8d841a100a4eb20d22e135142bf5b0f2120722fd420e166e5
+ENV GIT_DOWNLOAD_SHA256 fd1937ea8468461d35d9cabfcdd2daa3a74509dc9213c43c2b9615e8f0b85086
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	(New-Object System.Net.WebClient).DownloadFile($env:GIT_DOWNLOAD_URL, 'git.exe'); \
@@ -60,9 +60,9 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.8beta1
+ENV GOLANG_VERSION 1.8beta2
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip
-ENV GOLANG_DOWNLOAD_SHA256 7b246c37dfe37348a16b6bc1865ebc21a79c4fd869032fba78c65e46b11b741b
+ENV GOLANG_DOWNLOAD_SHA256 23adb702c957f73ee5ffb35bac7587c4064a00d150edf5b477f042774e097b85
 
 RUN Write-Host ('Downloading {0} ...' -f $env:GOLANG_DOWNLOAD_URL); \
 	(New-Object System.Net.WebClient).DownloadFile($env:GOLANG_DOWNLOAD_URL, 'go.zip'); \

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -62,7 +62,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 
 ENV GOLANG_VERSION 1.8beta2
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip
-ENV GOLANG_DOWNLOAD_SHA256 23adb702c957f73ee5ffb35bac7587c4064a00d150edf5b477f042774e097b85
+ENV GOLANG_DOWNLOAD_SHA256 98e44960cdbdd9f42fb466bfd02b347a78fab9b9e48744ea86e02d9d19439ee1
 
 RUN Write-Host ('Downloading {0} ...' -f $env:GOLANG_DOWNLOAD_URL); \
 	(New-Object System.Net.WebClient).DownloadFile($env:GOLANG_DOWNLOAD_URL, 'go.zip'); \

--- a/golang/build.bat
+++ b/golang/build.bat
@@ -1,3 +1,3 @@
 docker build -t golang .
 if %errorlevel% neq 0 exit /b %errorlevel%
-docker tag golang:latest golang:1.8beta1
+docker tag golang:latest golang:1.8beta2

--- a/golang/push.bat
+++ b/golang/push.bat
@@ -1,0 +1,4 @@
+docker tag dockertls stefanscherer/golang-windows:1.8beta2
+docker tag dockertls stefanscherer/golang-windows
+docker push stefanscherer/golang-windows:1.8beta2
+docker push stefanscherer/golang-windows


### PR DESCRIPTION
Update Golang to 1.8beta2,
update Git for Windows to 2.11.0
