### PR TITLE
Use TLS 1.2 for ftp.openbsd.org

### DIFF
--- a/dockertls/Dockerfile
+++ b/dockertls/Dockerfile
@@ -6,8 +6,7 @@ ENV VERSION 2.5.0
 
 ENV LIBRESSLPATH C:\libressl
 
-# Remark: openbsd's SSL seems to be wonky (ironically)
-RUN [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12' ; \
+RUN [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls12' ; \
 	Invoke-WebRequest "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$Env:VERSION-windows.zip" -OutFile libressl.zip -UseBasicParsing ; \
 	Expand-Archive libressl.zip -DestinationPath $Env:Temp ; \
 	New-Item -ItemType Directory -Path $Env:LIBRESSLPATH ; \


### PR DESCRIPTION
The ftp.openbsd.org website only supports TLS 1.2, as shown in https://www.ssllabs.com/ssltest/analyze.html?d=ftp.openbsd.org

So I remove all the older security protocols and the comment.

The default in a PowerShell terminal shows too old security options, just tested in microsoft/windowsservercore:10.0.14393.567

```
PS C:\> [System.Net.ServicePointManager]::SecurityProtocol
Ssl3, Tls
```

FYI @friism 