### PR TITLE
Build dockertls image with nanoserver

### DIFF
--- a/dockertls/Dockerfile
+++ b/dockertls/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore
+FROM microsoft/nanoserver
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -6,14 +6,13 @@ ENV VERSION 2.4.4
 
 ENV LIBRESSLPATH C:\libressl
 
-RUN [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls12' ; \
-	Invoke-WebRequest "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$Env:VERSION-windows.zip" -OutFile libressl.zip -UseBasicParsing ; \
+RUN Invoke-WebRequest "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$Env:VERSION-windows.zip" -OutFile libressl.zip -UseBasicParsing ; \
 	Expand-Archive libressl.zip -DestinationPath $Env:Temp ; \
 	New-Item -ItemType Directory -Path $Env:LIBRESSLPATH ; \
 	Copy-Item $Env:Temp\libressl-$Env:VERSION-windows\x64\* $Env:LIBRESSLPATH\. ; \
 	Remove-Item $Env:LIBRESSLPATH\*.pdb ; \
 	$newPath = ('{0};{1}' -f $Env:LIBRESSLPATH, $Env:PATH); \
-	setx /M PATH $newPath; \
+	Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $newPath ; \
 	Remove-Item $Env:Temp\libressl-$Env:VERSION-windows, libressl.zip -Force -Recurse ; \
 	New-Item -ItemType Directory -Path $Env:LIBRESSLPATH\ssl
 

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -79,8 +79,6 @@ docker run --rm `
   -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
 ```
 
-
-
 ## Managing Multiple Hosts
 
 ### First Host


### PR DESCRIPTION
Switch to nanoserver base image
It seems that the default Invoke-WebRequest in NanoServer supports TLS 1.2.
