### PR TITLE
Build nanoserver image with golang and git

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,87 +1,13 @@
-FROM microsoft/windowsservercore
+FROM golang:1.8-nanoserver
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-# install Git (especially for "go get")
 ENV GIT_VERSION 2.11.0
-ENV GIT_TAG v${GIT_VERSION}.windows.1
-ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/Git-${GIT_VERSION}-64-bit.exe
-ENV GIT_DOWNLOAD_SHA256 fd1937ea8468461d35d9cabfcdd2daa3a74509dc9213c43c2b9615e8f0b85086
-# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
-RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
-	(New-Object System.Net.WebClient).DownloadFile($env:GIT_DOWNLOAD_URL, 'git.exe'); \
-	\
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
-	if ((Get-FileHash git.exe -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	Write-Host 'Installing ...'; \
-	Start-Process \
-		-Wait \
-		-FilePath ./git.exe \
-# http://www.jrsoftware.org/ishelp/topic_setupcmdline.htm
-		-ArgumentList @( \
-			'/VERYSILENT', \
-			'/NORESTART', \
-			'/NOCANCEL', \
-			'/SP-', \
-			'/SUPPRESSMSGBOXES', \
-			\
-# https://github.com/git-for-windows/build-extra/blob/353f965e0e2af3e8c993930796975f9ce512c028/installer/install.iss#L87-L96
-			'/COMPONENTS=assoc_sh', \
-			\
-# set "/DIR" so we can set "PATH" afterwards
-# see https://disqus.com/home/discussion/chocolatey/chocolatey_gallery_git_install_1710/#comment-2834659433 for why we don't use "/LOADINF=..." to let the installer set PATH
-			'/DIR=C:\git' \
-		); \
-	\
-	Write-Host 'Updating PATH ...'; \
-	$env:PATH = 'C:\git\bin;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
-	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
-	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  git --version'; git --version; \
-	Write-Host '  bash --version'; bash --version; \
-	Write-Host '  curl --version'; curl.exe --version; \
-	\
-	Write-Host 'Removing installer ...'; \
-	Remove-Item git.exe -Force; \
-	\
-	Write-Host 'Complete.';
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/v${GIT_VERSION}.windows.1/MinGit-${GIT_VERSION}-64-bit.zip
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
-ENV GOPATH C:\\gopath
-
-# PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
-	Write-Host ('Updating PATH: {0}' -f $newPath); \
-	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
-# doing this first to share cache across versions more aggressively
-
-ENV GOLANG_VERSION 1.8beta2
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip
-ENV GOLANG_DOWNLOAD_SHA256 98e44960cdbdd9f42fb466bfd02b347a78fab9b9e48744ea86e02d9d19439ee1
-
-RUN Write-Host ('Downloading {0} ...' -f $env:GOLANG_DOWNLOAD_URL); \
-	(New-Object System.Net.WebClient).DownloadFile($env:GOLANG_DOWNLOAD_URL, 'go.zip'); \
-	\
-	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GOLANG_DOWNLOAD_SHA256); \
-	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $env:GOLANG_DOWNLOAD_SHA256) { \
-		Write-Host 'FAILED!'; \
-		exit 1; \
-	}; \
-	\
-	Write-Host 'Expanding ...'; \
-	Expand-Archive go.zip -DestinationPath C:\; \
-	\
-	Write-Host 'Verifying install ("go version") ...'; \
-	go version; \
-	\
-	Write-Host 'Removing ...'; \
-	Remove-Item go.zip -Force; \
-	\
-	Write-Host 'Complete.';
-
-WORKDIR $GOPATH
+RUN Invoke-WebRequest -UseBasicParsing $env:GIT_DOWNLOAD_URL -OutFile git.zip; \
+    Expand-Archive git.zip -DestinationPath C:\git; \
+    Remove-Item git.zip; \
+    Write-Host 'Updating PATH ...'; \
+    $env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH

--- a/golang/test.bat
+++ b/golang/test.bat
@@ -1,0 +1,2 @@
+docker run golang go version
+docker run golang git --version


### PR DESCRIPTION
The official golang image for nanoserver does not have Git installed. See explanation in https://github.com/docker-library/golang/issues/140

This PR creates a Docker image based on the official and installs Git.
