### PR TITLE
Build traefik nanoserver image

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,0 +1,21 @@
+FROM microsoft/nanoserver
+
+# ADD https://github.com/containous/traefik/releases/download/v1.1.2/traefik_windows-amd64 /traefik.exe
+ADD https://github.com/StefanScherer/traefik/releases/download/v1.1.2-windows/traefik_windows-amd64 /traefik.exe
+
+VOLUME C:/etc/traefik
+VOLUME C:/etc/ssl
+RUN powershell -command \
+    set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'T:' -Value '\??\C:\etc\traefik' -Type String ; \
+    set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'S:' -Value '\??\C:\etc\ssl' -Type String
+
+EXPOSE 80
+ENTRYPOINT ["/traefik", "--configfile=T:/traefik.toml"]
+
+# Metadata
+LABEL org.label-schema.vendor="Containous" \
+      org.label-schema.url="https://traefik.io" \
+      org.label-schema.name="Traefik" \
+      org.label-schema.description="A modern reverse-proxy" \
+      org.label-schema.version="v1.1.2" \
+      org.label-schema.docker.schema-version="1.0"

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -1,0 +1,64 @@
+![](https://traefik.io/traefik.logo.svg)
+
+[Træfɪk](https://github.com/containous/traefik) is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease. It supports several backends ([Docker :whale:](https://www.docker.com/), [Swarm :whale::whale:](https://github.com/docker/swarm), [Mesos/Marathon](https://mesosphere.github.io/marathon/), [Consul](https://www.consul.io/), [Etcd](https://coreos.com/etcd/), [Zookeeper](https://zookeeper.apache.org), [BoltDB](https://github.com/boltdb/bolt), Rest API, file...) to manage its configuration automatically and dynamically.
+
+# Example usage
+
+Grab a [sample configuration file](https://raw.githubusercontent.com/containous/traefik/master/traefik.sample.toml) and rename it to `traefik.toml`. Enable `docker` provider and web UI:
+
+```toml
+################################################################
+# Web configuration backend
+################################################################
+[web]
+address = ":8080"
+################################################################
+# Docker configuration backend
+################################################################
+[docker]
+domain = "docker.local"
+watch = true
+# increase docker api version to 1.24 with swarm-mode :-)
+swarmmode = true
+```
+
+Start Træfɪk:
+
+```bash
+docker run -it -v C:$(pwd):C:/etc/traefik -v C:/Users/vagrant/.docker:C:/etc/ssl -p 8080:8080 -p 80:80 traefik --docker.endpoint=tcp://172.31.80.1:2375
+```
+
+Start a backend server, named `test`:
+
+```bash
+docker run -d --name test stefanscherer/whoami-windows
+```
+
+And finally, you can access to your `whoami` server throught Træfɪk, on the domain name `{containerName}.{configuredDomain}`:
+
+```bash
+curl --header 'Host: test.docker.local' 'http://localhost:80/'
+Hostname: 117c5530934d
+IP: 127.0.0.1
+IP: ::1
+IP: 172.17.0.3
+IP: fe80::42:acff:fe11:3
+GET / HTTP/1.1
+Host: 172.17.0.3:80
+User-Agent: curl/7.35.0
+Accept: */*
+Accept-Encoding: gzip
+X-Forwarded-For: 172.17.0.1
+X-Forwarded-Host: 172.17.0.3:80
+X-Forwarded-Proto: http
+X-Forwarded-Server: f2e05c433120
+
+```
+
+The web UI [http://localhost:8080](http://localhost:8080) will give you an overview of the frontends/backends and also a health dashboard.
+
+![Web UI Providers](https://traefik.io/web.frontend.png)
+
+# Documentation
+
+You can find the complete documentation [here](https://docs.traefik.io).

--- a/traefik/build.bat
+++ b/traefik/build.bat
@@ -1,0 +1,1 @@
+docker build -t traefik .

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2.1'
+services:
+  traefik:
+    image: traefik
+    # we need the IP of the vEthernet (HNS Internal NIC)
+    command: --docker.endpoint=tcp://172.31.80.1:2375 --logLevel=DEBUG
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - .:C:/etc/traefik
+
+  whoami1:
+    image: stefanscherer/whoami-windows
+    labels:
+      - "traefik.backend=whoami"
+      - "traefik.frontend.rule=Host:whoami.docker.local"
+
+  whoami2:
+    image: stefanscherer/whoami-windows
+    labels:
+      - "traefik.backend=whoami"
+      - "traefik.frontend.rule=Host:whoami.docker.local"
+
+networks:
+  default:
+    external:
+      name: nat

--- a/traefik/push.bat
+++ b/traefik/push.bat
@@ -1,0 +1,2 @@
+docker tag traefik stefanscherer/traefik-windows
+docker push stefanscherer/traefik-windows

--- a/traefik/test.bat
+++ b/traefik/test.bat
@@ -1,1 +1,1 @@
-docker run traefik --help
+docker run traefik --help 2>&1

--- a/traefik/test.bat
+++ b/traefik/test.bat
@@ -1,0 +1,1 @@
+docker run traefik --help

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -1,0 +1,27 @@
+################################################################
+# Web configuration backend
+################################################################
+[web]
+address = ":8080"
+################################################################
+# Docker configuration backend
+################################################################
+[docker]
+domain = "docker.local"
+watch = true
+# Use Swarm Mode services as data provider
+#
+# Optional
+# Default: false
+#
+#swarmmode = true
+
+################################################################
+# Enable docker TLS connection
+# use -v path-on-host-to-tls-certs:C:\etc\ssl and the certs
+# will appear in drive S:
+################################################################
+# [docker.tls]
+# ca = "S:/ca.pem"
+# cert = "S:/cert.pem"
+# key = "S:/key.pem"


### PR DESCRIPTION
Build a nanoserver image with traefik proxy.
The traefik.exe binary is modified to use Docker API version 1.24 instead of 1.21.
