### PR TITLE
Use binary from Travis build to fix UI

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,7 +1,7 @@
 FROM microsoft/nanoserver
 
 # ADD https://github.com/containous/traefik/releases/download/v1.1.2/traefik_windows-amd64 /traefik.exe
-ADD https://github.com/StefanScherer/traefik/releases/download/v1.1.2-windows-open/traefik_windows-amd64 /traefik.exe
+ADD https://github.com/StefanScherer/traefik/releases/download/v1.1.2-windows.1/traefik_windows-amd64 /traefik.exe
 
 VOLUME C:/etc/traefik
 VOLUME C:/etc/ssl

--- a/traefik/push.bat
+++ b/traefik/push.bat
@@ -1,2 +1,4 @@
 docker tag traefik stefanscherer/traefik-windows
+docker tag traefik stefanscherer/traefik-windows:v1.1.2-windows.1
+docker push stefanscherer/traefik-windows:v1.1.2-windows.1
 docker push stefanscherer/traefik-windows


### PR DESCRIPTION
This fixes #75, the patched traefik.exe with the updated Docker API version = 1.24 has been compiled with Travis and pushed to GH releases.
