### PR TITLE
Use upstream traefik binary

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,12 @@
 version: 1.0.{build}
+image: Windows Server 2016
+
 environment:
   DOCKER_USER:
     secure: LjNiW/ZWrfVIJn3Mc9foeg==
   DOCKER_PASS:
     secure: 4gsl5WiqIztEWhL5fuhp9X0qT/mKg9fYzKYUUPf5WStIuNddv0fvIKGmvvyuFzzd
 install:
-  - choco install -y docker -pre
   - docker version
 
 build_script:

--- a/build.ps1
+++ b/build.ps1
@@ -6,13 +6,6 @@ Write-Host Updating base images
 docker pull microsoft/windowsservercore
 docker pull microsoft/nanoserver
 
-Write-Host Removing old images
-$ErrorActionPreference = 'SilentlyContinue';
-docker rmi $(docker images --no-trunc --format '{{.Repository}}:{{.Tag}}' | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))')
-$ErrorActionPreference = 'Stop';
-Write-Host Prune system
-docker system prune -f
-
 if ( $env:APPVEYOR_PULL_REQUEST_NUMBER ) {
   Write-Host Pull request $env:APPVEYOR_PULL_REQUEST_NUMBER
   $files = $(git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD master))

--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,7 +1,6 @@
 FROM microsoft/nanoserver
 
-# ADD https://github.com/containous/traefik/releases/download/v1.1.2/traefik_windows-amd64 /traefik.exe
-ADD https://github.com/StefanScherer/traefik/releases/download/v1.1.2-windows.1/traefik_windows-amd64 /traefik.exe
+ADD https://github.com/containous/traefik/releases/download/v1.2.0-rc1/traefik_windows-amd64 /traefik.exe
 
 VOLUME C:/etc/traefik
 VOLUME C:/etc/ssl
@@ -17,5 +16,5 @@ LABEL org.label-schema.vendor="Containous" \
       org.label-schema.url="https://traefik.io" \
       org.label-schema.name="Traefik" \
       org.label-schema.description="A modern reverse-proxy" \
-      org.label-schema.version="v1.1.2" \
+      org.label-schema.version="v1.2.0-rc1" \
       org.label-schema.docker.schema-version="1.0"

--- a/traefik/push.bat
+++ b/traefik/push.bat
@@ -1,4 +1,4 @@
 docker tag traefik stefanscherer/traefik-windows
-docker tag traefik stefanscherer/traefik-windows:v1.1.2-windows.1
-docker push stefanscherer/traefik-windows:v1.1.2-windows.1
+docker tag traefik stefanscherer/traefik-windows:v1.2.0-rc1-windows.1
+docker push stefanscherer/traefik-windows:v1.2.0-rc1-windows.1
 docker push stefanscherer/traefik-windows

--- a/traefik/traefik-dockertls.toml
+++ b/traefik/traefik-dockertls.toml
@@ -1,0 +1,27 @@
+################################################################
+# Web configuration backend
+################################################################
+[web]
+address = ":8080"
+################################################################
+# Docker configuration backend
+################################################################
+[docker]
+domain = "docker.local"
+watch = true
+# Use Swarm Mode services as data provider
+#
+# Optional
+# Default: false
+#
+#swarmmode = true
+
+################################################################
+# Enable docker TLS connection
+# use -v path-on-host-to-tls-certs:C:\etc\ssl and the certs
+# will appear in drive S:
+################################################################
+[docker.tls]
+ca = "S:/ca.pem"
+cert = "S:/cert.pem"
+key = "S:/key.pem"

--- a/traefik/traefik-letsencrypt.toml
+++ b/traefik/traefik-letsencrypt.toml
@@ -1,0 +1,108 @@
+################################################################
+# Web configuration backend
+################################################################
+[web]
+address = ":8080"
+################################################################
+# Docker configuration backend
+################################################################
+[docker]
+domain = "yourdomain.com"
+watch = true
+# Use Swarm Mode services as data provider
+#
+# Optional
+# Default: false
+#
+#swarmmode = true
+
+################################################################
+# Enable docker TLS connection
+# use -v path-on-host-to-tls-certs:C:\etc\ssl and the certs
+# will appear in drive S:
+################################################################
+#[docker.tls]
+#ca = "S:/ca.pem"
+#cert = "S:/cert.pem"
+#key = "S:/key.pem"
+
+# Sample entrypoint configuration when using ACME
+[entryPoints]
+  [entryPoints.https]
+  address = ":443"
+    [entryPoints.https.tls]
+
+# Enable ACME (Let's Encrypt): automatic SSL
+#
+# Optional
+#
+[acme]
+
+# Email address used for registration
+#
+# Required
+#
+email = "your@email.address"
+
+# File or key used for certificates storage.
+# WARNING, if you use Traefik in Docker, you have 2 options:
+#  - create a file on your host and mount it as a volume
+#      storageFile = "acme.json"
+#      $ docker run -v "/my/host/acme.json:acme.json" traefik
+#  - mount the folder containing the file as a volume
+#      storageFile = "/etc/traefik/acme/acme.json"
+#      $ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
+#
+# Required
+#
+storage = "T:/acme.json" # or "traefik/acme/account" if using KV store
+
+# Entrypoint to proxy acme challenge to.
+# WARNING, must point to an entrypoint on port 443
+#
+# Required
+#
+entryPoint = "https"
+
+# Enable on demand certificate. This will request a certificate from Let's Encrypt during the first TLS handshake for a hostname that does not yet have a certificate.
+# WARNING, TLS handshakes will be slow when requesting a hostname certificate for the first time, this can leads to DoS attacks.
+# WARNING, Take note that Let's Encrypt have rate limiting: https://letsencrypt.org/docs/rate-limits
+#
+# Optional
+#
+# onDemand = true
+
+# Enable certificate generation on frontends Host rules. This will request a certificate from Let's Encrypt for each frontend with a Host rule.
+# For example, a rule Host:test1.traefik.io,test2.traefik.io will request a certificate with main domain test1.traefik.io and SAN test2.traefik.io.
+#
+# Optional
+#
+# OnHostRule = true
+
+# CA server to use
+# Uncomment the line to run on the staging let's encrypt server
+# Leave comment to go to prod
+#
+# Optional
+#
+# caServer = "https://acme-staging.api.letsencrypt.org/directory"
+
+# Domains list
+# You can provide SANs (alternative domains) to each main domain
+# All domains must have A/AAAA records pointing to Traefik
+# WARNING, Take note that Let's Encrypt have rate limiting: https://letsencrypt.org/docs/rate-limits
+# Each domain & SANs will lead to a certificate request.
+#
+# [[acme.domains]]
+#   main = "local1.com"
+#   sans = ["test1.local1.com", "test2.local1.com"]
+# [[acme.domains]]
+#   main = "local2.com"
+#   sans = ["test1.local2.com", "test2x.local2.com"]
+# [[acme.domains]]
+#   main = "local3.com"
+# [[acme.domains]]
+#   main = "local4.com"
+[[acme.domains]]
+   main = "yourdomain.com"
+   sans = ["whoami.yourdomain.com"] #, "portainer.yourdomain.com"]


### PR DESCRIPTION
After the corrections for Windows have been merged into upstream Traefik repo, use the latest upstream binary.
