### PR TITLE
Build a Serverspec base image for Windows

### DIFF
--- a/serverspec/.dockerignore
+++ b/serverspec/.dockerignore
@@ -1,0 +1,4 @@
+*.md
+spec/
+Dockerfile
+.dockerignore

--- a/serverspec/Dockerfile
+++ b/serverspec/Dockerfile
@@ -1,0 +1,26 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV chocolateyUseWindowsCompression=false
+
+RUN iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex ; \
+    choco install -y ruby
+
+# http://guides.rubygems.org/ssl-certificate-update/#installing-using-update-packages
+RUN Invoke-WebRequest -Uri https://rubygems.org/downloads/rubygems-update-2.6.7.gem -OutFile C:\rubygems-update-2.6.7.gem ; \
+    gem install --local C:\rubygems-update-2.6.7.gem ; \
+    update_rubygems --no-ri --no-rdoc ; \
+    gem uninstall rubygems-update -x ; \
+    gem install bundler
+
+WORKDIR /code
+COPY . /code
+
+RUN bundle config --local path vendor/bundle ; \
+    bundle install
+
+VOLUME C:/spec
+RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'S:' -Value '\??\C:\spec' -Type String
+
+CMD ["bundle.bat", "exec", "rspec", "--color", "--format", "documentation", "S:/*_spec.rb"]

--- a/serverspec/Gemfile
+++ b/serverspec/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gem "serverspec"
+gem "json_pure"
+gem "serverspec-extended-types"

--- a/serverspec/Gemfile.lock
+++ b/serverspec/Gemfile.lock
@@ -1,0 +1,56 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
+    json_pure (2.0.3)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (4.0.1)
+    net-telnet (0.1.1)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    serverspec (2.38.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.53)
+    serverspec-extended-types (0.0.3)
+      faraday
+      rspec (>= 3.0)
+      serverspec (~> 2)
+      specinfra (~> 2)
+    sfl (2.3)
+    specinfra (2.66.7)
+      net-scp
+      net-ssh (>= 2.7, < 5.0)
+      net-telnet
+      sfl
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json_pure
+  serverspec
+  serverspec-extended-types
+
+BUNDLED WITH
+   1.14.3

--- a/serverspec/README.md
+++ b/serverspec/README.md
@@ -1,0 +1,46 @@
+# Run Serverspec tests in a Windows container
+
+[Dockerfile](https://github.com/StefanScherer/dockerfiles-windows/blob/master/serverspec/Dockerfile)
+
+This is a Windows Docker image with [Serverspec](http://serverspec.org) installed.
+
+You can run isolated Serverspec tests in Windows containers, eg. to test all
+scenarios of an own built MSI package.
+
+Each container starts without your MSI package installed, so you don't need
+a snapshot of your VM.
+
+## Example
+
+To run the Serverspec tests create a folder `spec` with some `*_spec.rb` files.
+See the [spec](https://github.com/StefanScherer/dockerfiles-windows/tree/master/serverspec/spec) folder to selftest this Docker image for an example.
+
+Run the container like this:
+
+```
+PS C:\> docker run -v "$(pwd)/spec:C:/spec" stefanscherer/serverspec-windows
+
+Chocolatey
+  File "C:\ProgramData/chocolatey/bin"
+    should exist
+  Command "choco version"
+    exit_status
+      should eq 0
+    stdout
+      should match /Chocolatey v0.10.3/
+
+Ruby
+  Command "ruby --version"
+    exit_status
+      should eq 0
+    stdout
+      should match /ruby 2.3.1p112/
+  Command "bundle version"
+    exit_status
+      should eq 0
+    stdout
+      should match /Bundler version 1.14.3/
+
+Finished in 10.25 seconds (files took 1.77 seconds to load)
+7 examples, 0 failures
+```

--- a/serverspec/build.bat
+++ b/serverspec/build.bat
@@ -1,0 +1,1 @@
+docker build -t serverspec .

--- a/serverspec/push.bat
+++ b/serverspec/push.bat
@@ -1,0 +1,4 @@
+docker tag serverspec stefanscherer/serverspec-windows
+docker tag serverspec stefanscherer/serverspec-windows:2.38.0
+docker push stefanscherer/serverspec-windows:2.38.0
+docker push stefanscherer/serverspec-windows

--- a/serverspec/spec/chocolatey_spec.rb
+++ b/serverspec/spec/chocolatey_spec.rb
@@ -1,0 +1,15 @@
+require "serverspec"
+
+set :backend, :cmd
+set :os, :family => 'windows'
+
+describe "Chocolatey" do
+  describe file("#{ENV['ProgramData']}/chocolatey/bin") do
+    it { should exist }
+  end
+
+  describe command('choco version') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match /Chocolatey v0.10.3/ }
+  end
+end

--- a/serverspec/spec/ruby_spec.rb
+++ b/serverspec/spec/ruby_spec.rb
@@ -1,0 +1,16 @@
+require "serverspec"
+
+set :backend, :cmd
+set :os, :family => 'windows'
+
+describe "Ruby" do
+  describe command('ruby --version') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match /ruby 2.3.1p112/ }
+  end
+
+  describe command('bundle version') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match /Bundler version 1.14.3/ }
+  end
+end

--- a/serverspec/test.bat
+++ b/serverspec/test.bat
@@ -1,0 +1,1 @@
+docker run -v %cd%\spec:C:\spec serverspec


### PR DESCRIPTION
# Run Serverspec tests in a Windows container

[Dockerfile](https://github.com/StefanScherer/dockerfiles-windows/blob/master/serverspec/Dockerfile)

This is a Windows Docker image with [Serverspec](http://serverspec.org) installed.

You can run isolated Serverspec tests in Windows containers, eg. to test all
scenarios of an own built MSI package.

Each container starts without your MSI package installed, so you don't need
a snapshot of your VM.

## Example

To run the Serverspec tests create a folder `spec` with some `*_spec.rb` files.
See the [spec](https://github.com/StefanScherer/dockerfiles-windows/tree/master/serverspec/spec) folder to selftest this Docker image for an example.

Run the container like this:

```
PS C:\> docker run -v "$(pwd)/spec:C:/spec" stefanscherer/serverspec-windows

Chocolatey
  File "C:\ProgramData/chocolatey/bin"
    should exist
  Command "choco version"
    exit_status
      should eq 0
    stdout
      should match /Chocolatey v0.10.3/

Ruby
  Command "ruby --version"
    exit_status
      should eq 0
    stdout
      should match /ruby 2.3.1p112/
  Command "bundle version"
    exit_status
      should eq 0
    stdout
      should match /Bundler version 1.14.3/

Finished in 10.25 seconds (files took 1.77 seconds to load)
7 examples, 0 failures
```
