### PR TITLE
Update Traefik 1.2.0-rc2

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,12 +1,9 @@
 FROM microsoft/nanoserver
 
-ADD https://github.com/containous/traefik/releases/download/v1.2.0-rc1/traefik_windows-amd64 /traefik.exe
+ADD https://github.com/containous/traefik/releases/download/v1.2.0-rc2/traefik_windows-amd64 /traefik.exe
 
 VOLUME C:/etc/traefik
 VOLUME C:/etc/ssl
-RUN powershell -command \
-    set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'T:' -Value '\??\C:\etc\traefik' -Type String ; \
-    set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'S:' -Value '\??\C:\etc\ssl' -Type String
 
 EXPOSE 80
 ENTRYPOINT ["/traefik", "--configfile=T:/traefik.toml"]
@@ -16,5 +13,5 @@ LABEL org.label-schema.vendor="Containous" \
       org.label-schema.url="https://traefik.io" \
       org.label-schema.name="Traefik" \
       org.label-schema.description="A modern reverse-proxy" \
-      org.label-schema.version="v1.2.0-rc1" \
+      org.label-schema.version="v1.2.0-rc2" \
       org.label-schema.docker.schema-version="1.0"

--- a/traefik/push.bat
+++ b/traefik/push.bat
@@ -1,4 +1,4 @@
 docker tag traefik stefanscherer/traefik-windows
-docker tag traefik stefanscherer/traefik-windows:v1.2.0-rc1
-docker push stefanscherer/traefik-windows:v1.2.0-rc1
+docker tag traefik stefanscherer/traefik-windows:v1.2.0-rc2
+docker push stefanscherer/traefik-windows:v1.2.0-rc2
 docker push stefanscherer/traefik-windows


### PR DESCRIPTION
- Update Traefik 1.2.0-rc2
- Cleanup Dockerfile, no mapped drives needed
