### PR TITLE
Fix configfile path for traefik

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -6,7 +6,7 @@ VOLUME C:/etc/traefik
 VOLUME C:/etc/ssl
 
 EXPOSE 80
-ENTRYPOINT ["/traefik", "--configfile=T:/traefik.toml"]
+ENTRYPOINT ["/traefik", "--configfile=C:/etc/traefik/traefik.toml"]
 
 # Metadata
 LABEL org.label-schema.vendor="Containous" \


### PR DESCRIPTION
Change the path to the configfile from T: to C:/etc/traefik as there is no need for the drive subtitution.
