### PR TITLE
Update Node 4.8.2, 6.10.2 + Use gpg signature check and multi-stage build

### DIFF
--- a/node/4.8/Dockerfile
+++ b/node/4.8/Dockerfile
@@ -2,17 +2,45 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.8.1
-ENV NODE_SHA256 edb47c31de7891ddb58d5e1024e31c91b49b4f2226cf6c3e0c41e715ee6111e4
+ENV GPG_VERSION 2.3.3
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 4.8.2
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
 
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
-    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
     Expand-Archive node.zip -DestinationPath C:\ ; \
-    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
-    New-Item $($env:APPDATA + '\npm') ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=0 /nodejs /nodejs
+
+RUN New-Item $($env:APPDATA + '\npm') ; \
     $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
-    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
-    Remove-Item -Path node.zip
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
 CMD [ "node.exe" ]

--- a/node/4.8/README.md
+++ b/node/4.8/README.md
@@ -1,12 +1,12 @@
 # Node
 
-A Windows Server Core Docker container image with Node.js 4.8.1 installed.
+A Windows Server Core Docker container image with Node.js 4.8.2 installed.
 
 ## Building
 
 ```
 docker build -t node .
-docker tag node:latest node:4.8.1
+docker tag node:latest node:4.8.2
 ```
 
 ## Onbuild

--- a/node/4.8/nano/Dockerfile
+++ b/node/4.8/nano/Dockerfile
@@ -1,18 +1,46 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.3
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 4.8.2
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
 FROM microsoft/nanoserver
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.8.1
-ENV NODE_SHA256 edb47c31de7891ddb58d5e1024e31c91b49b4f2226cf6c3e0c41e715ee6111e4
 
-RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
-    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
-    Expand-Archive node.zip -DestinationPath C:\ ; \
-    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
-    New-Item $($env:APPDATA + '\npm') ; \
+COPY --from=0 /nodejs /nodejs
+
+RUN New-Item $($env:APPDATA + '\npm') ; \
     $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
-    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH ; \
-    Remove-Item -Path node.zip
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH
 
 CMD [ "node.exe" ]

--- a/node/4.8/nano/onbuild/Dockerfile
+++ b/node/4.8/nano/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.8.1-nanoserver
+FROM node:4.8.2-nanoserver
 
 RUN mkdir \app
 WORKDIR /app

--- a/node/4.8/onbuild/Dockerfile
+++ b/node/4.8/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.8.1-windowsservercore
+FROM node:4.8.2-windowsservercore
 
 RUN mkdir \app
 WORKDIR /app

--- a/node/6.10/Dockerfile
+++ b/node/6.10/Dockerfile
@@ -2,17 +2,45 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.10.1
-ENV NODE_SHA256 28923f51691bb34dc399af4ceb567da487d7f4806aec5e6f0cfab1e6c3f2dd1c
+ENV GPG_VERSION 2.3.3
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 6.10.2
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
 
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
-    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
     Expand-Archive node.zip -DestinationPath C:\ ; \
-    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
-    New-Item $($env:APPDATA + '\npm') ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=0 /nodejs /nodejs
+
+RUN New-Item $($env:APPDATA + '\npm') ; \
     $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
-    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
-    Remove-Item -Path node.zip
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
 CMD [ "node.exe" ]

--- a/node/6.10/README.md
+++ b/node/6.10/README.md
@@ -1,12 +1,12 @@
 # Node
 
-A Windows Server Core Docker container image with Node.js 6.10.1 installed.
+A Windows Server Core Docker container image with Node.js 6.10.2 installed.
 
 ## Building
 
 ```
 docker build -t node .
-docker tag node:latest node:6.10.1
+docker tag node:latest node:6.10.2
 ```
 
 ## Onbuild

--- a/node/6.10/nano/Dockerfile
+++ b/node/6.10/nano/Dockerfile
@@ -1,18 +1,46 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.3
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 6.10.2
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
 FROM microsoft/nanoserver
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.10.1
-ENV NODE_SHA256 28923f51691bb34dc399af4ceb567da487d7f4806aec5e6f0cfab1e6c3f2dd1c
 
-RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
-		if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
-    Expand-Archive node.zip -DestinationPath C:\ ; \
-    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
-    New-Item $($env:APPDATA + '\npm') ; \
+COPY --from=0 /nodejs /nodejs
+
+RUN New-Item $($env:APPDATA + '\npm') ; \
     $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
-    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH ; \
-    Remove-Item -Path node.zip
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH
 
 CMD [ "node.exe" ]

--- a/node/6.10/nano/onbuild/Dockerfile
+++ b/node/6.10/nano/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10.1-nanoserver
+FROM node:6.10.2-nanoserver
 
 RUN mkdir \app
 WORKDIR /app

--- a/node/6.10/onbuild/Dockerfile
+++ b/node/6.10/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10.1-windowsservercore
+FROM node:6.10.2-windowsservercore
 
 RUN mkdir \app
 WORKDIR /app

--- a/node/7.8/Dockerfile
+++ b/node/7.8/Dockerfile
@@ -2,17 +2,49 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV NPM_CONFIG_LOGLEVEL info
+ENV GPG_VERSION 2.3.3
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
 ENV NODE_VERSION 7.8.0
-ENV NODE_SHA256 49eb820e2e8a01c6b9c2f94e019ee4149ce01553a809dc39eebdc83a1fa1792d
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
 
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
-    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
     Expand-Archive node.zip -DestinationPath C:\ ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
     New-Item $($env:APPDATA + '\npm') ; \
     $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
     [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
     Remove-Item -Path node.zip
+
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=0 /nodejs /nodejs
+
+RUN New-Item $($env:APPDATA + '\npm') ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
 
 CMD [ "node.exe" ]

--- a/node/7.8/Dockerfile
+++ b/node/7.8/Dockerfile
@@ -29,11 +29,7 @@ RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f 
     $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
     if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
     Expand-Archive node.zip -DestinationPath C:\ ; \
-    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
-    New-Item $($env:APPDATA + '\npm') ; \
-    $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
-    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
-    Remove-Item -Path node.zip
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
 
 FROM microsoft/windowsservercore
 
@@ -45,6 +41,6 @@ COPY --from=0 /nodejs /nodejs
 
 RUN New-Item $($env:APPDATA + '\npm') ; \
     $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
-    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
 CMD [ "node.exe" ]

--- a/node/7.8/nano/Dockerfile
+++ b/node/7.8/nano/Dockerfile
@@ -1,18 +1,46 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.3
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 7.8.0
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
 FROM microsoft/nanoserver
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 7.8.0
-ENV NODE_SHA256 49eb820e2e8a01c6b9c2f94e019ee4149ce01553a809dc39eebdc83a1fa1792d
 
-RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
-		if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
-    Expand-Archive node.zip -DestinationPath C:\ ; \
-    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
-    New-Item $($env:APPDATA + '\npm') ; \
+COPY --from=0 /nodejs /nodejs
+
+RUN New-Item $($env:APPDATA + '\npm') ; \
     $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
-    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH ; \
-    Remove-Item -Path node.zip
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH
 
 CMD [ "node.exe" ]

--- a/node/build.ps1
+++ b/node/build.ps1
@@ -1,3 +1,11 @@
+Write-Host Updating Docker engine to master for PR docker/docker#31257
+Stop-Service docker
+$wc = New-Object net.webclient
+$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/dockerd.exe", "$env:ProgramFiles\docker\dockerd.exe")
+$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/docker.exe", "$env:ProgramFiles\docker\docker.exe")
+Start-Service docker
+docker version
+
 function buildVersion($majorMinorPatch, $majorMinor, $major) {
   docker build -t node:$majorMinorPatch $majorMinor
   docker tag node:$majorMinorPatch node:latest

--- a/node/build.ps1
+++ b/node/build.ps1
@@ -28,6 +28,6 @@ function buildVersion($majorMinorPatch, $majorMinor, $major) {
   docker tag node:$majorMinorPatch-nano-onbuild node:$major-nano-onbuild
 }
 
-buildVersion "4.8.1" "4.8" "4"
-buildVersion "6.10.1" "6.10" "6"
+buildVersion "4.8.2" "4.8" "4"
+buildVersion "6.10.2" "6.10" "6"
 buildVersion "7.8.0" "7.8" "7"

--- a/node/push.ps1
+++ b/node/push.ps1
@@ -29,6 +29,6 @@ function pushVersion($majorMinorPatch, $majorMinor, $major) {
   docker push stefanscherer/node-windows:$major-nano-onbuild
 }
 
-pushVersion "4.8.1" "4.8" "4"
-pushVersion "6.10.1" "6.10" "6"
+pushVersion "4.8.2" "4.8" "4"
+pushVersion "6.10.2" "6.10" "6"
 pushVersion "7.8.0" "7.8" "7"

--- a/node/test.ps1
+++ b/node/test.ps1
@@ -9,6 +9,6 @@ function testVersion($majorMinorPatch) {
   $ErrorActionPreference = 'Stop';
 }
 
-testVersion ""
+testVersion "4.8.2"
 testVersion "6.10.2"
 testVersion "7.8.0"

--- a/node/test.ps1
+++ b/node/test.ps1
@@ -9,6 +9,6 @@ function testVersion($majorMinorPatch) {
   $ErrorActionPreference = 'Stop';
 }
 
-testVersion "4.8.1"
-testVersion "6.10.1"
+testVersion ""
+testVersion "6.10.2"
 testVersion "7.8.0"

--- a/node/update.sh
+++ b/node/update.sh
@@ -12,8 +12,6 @@ function update_version() {
   fi
 
   echo "Updating $curr -> $latest"
-  sha=$(curl -s https://nodejs.org/dist/latest-v${version}.x/SHASUMS256.txt | grep win-x64.zip | sed 's/ .*//')
-  echo "New SHA256 $sha"
 
   a=( ${curr//./ } )
   curr_major="${a[0]}"
@@ -22,7 +20,6 @@ function update_version() {
   latest_major="${a[0]}"
   latest_major_minor="${a[0]}.${a[1]}"
 
-  find ${curr_major_minor} -type f -exec sed -i "" "s/ENV NODE_SHA256.*/ENV NODE_SHA256 $sha/g" {} +
   find ${curr_major_minor} -type f -exec sed -i "" "s/${curr//./\\.}/$latest/g" {} +
   find build* -type f -exec sed -i "" "s/${curr//./\\.}/$latest/g" {} +
   find build* -type f -exec sed -i "" "s/${curr_major_minor//./\\.}/$latest_major_minor/g" {} +


### PR DESCRIPTION
To get rid of maintaining the sha256 checksums for each version of Node.js it would be better to use gpg signature checks as it is done for the Linux Docker images (eg. [nodejs/docker-node/7.8/Dockerfile](https://github.com/nodejs/docker-node/blob/74e5c8fec424379cdf3bd9bf44d46c5c07899ddb/7.8/Dockerfile)).

Install gpg on Windows isn't that easy and uninstalling the files and package would complicate the Dockerfile. 

multi-stage build for the rescue

Let's try it with AppVeyor.

This is a proof-of-concept for https://github.com/nodejs/docker-node/pull/362