### PR TITLE
Cleaner way to wait for vc_redist installation to finish

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -3,7 +3,7 @@ FROM microsoft/iis:windowsservercore
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV PHP_VERSION 7.1.3
-ENV PHP_SHA1 85c0215337b08f9d49c233c16475c15f17b66ac1
+ENV PHP_SHA1 4000132114cecdec82c83b09aed6a962ed928e0b
 
 WORKDIR /Users/ContainerAdministrator/Downloads
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -8,10 +8,8 @@ ENV PHP_SHA1 85c0215337b08f9d49c233c16475c15f17b66ac1
 WORKDIR /Users/ContainerAdministrator/Downloads
 
 # Visual C++ 2015 Redistributable
-# workaround: the .exe command completes early and does not finish the install, so added 10s sleep to the end to allow time to finish
 RUN Invoke-WebRequest 'https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe' -OutFile 'vc_redist.x64.exe'; \
-    .\vc_redist.x64.exe /install /passive /norestart; \
-    Start-Sleep -s 10; \
+    Start-Process '.\vc_redist.x64.exe' '/install /passive /norestart' -Wait; \
     Remove-Item vc_redist.x64.exe;
 
 # Install PHP

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -2,7 +2,7 @@ FROM microsoft/iis:windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV PHP_VERSION 7.1.0
+ENV PHP_VERSION 7.1.3
 ENV PHP_SHA1 85c0215337b08f9d49c233c16475c15f17b66ac1
 
 WORKDIR /Users/ContainerAdministrator/Downloads


### PR DESCRIPTION
Rather than waiting an arbitrary amout of time, we can use the Start-Process cmdlet and tell it to wait for the process to finish. I've used this with other Dockerfiles, including ones with msiexec commands, and it seems to do the job !