### PR TITLE
Add servername to subjectAltName for docker-compose

### DIFF
--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -42,7 +42,7 @@ function createCerts($serverCertsPath, $serverName, $ipAddresses, $clientCertsPa
   & openssl req -subj "/CN=$serverName/" -sha256 -new -key server-key.pem -out server.csr
 
   Write-Host "`n=== Signing Server request"
-  "subjectAltName = " + (($ipAddresses.Split(',') | ForEach-Object { "IP:$_" }) -join ',') | Out-File extfile.cnf -Encoding Ascii
+  "subjectAltName = " + (($ipAddresses.Split(',') | ForEach-Object { "IP:$_" }) -join ',') + ",DNS.1: $serverName" | Out-File extfile.cnf -Encoding Ascii
   cat extfile.cnf
   & openssl x509 -req -days 365 -sha256 -in server.csr -CA $Global:caPublicKeyFile -passin $Global:caPrivateKeyPass -CAkey $Global:caPrivateKeyFile `
     -CAcreateserial -out server-cert.pem -extfile extfile.cnf

--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -42,7 +42,7 @@ function createCerts($serverCertsPath, $serverName, $ipAddresses, $clientCertsPa
   & openssl req -subj "/CN=$serverName/" -sha256 -new -key server-key.pem -out server.csr
 
   Write-Host "`n=== Signing Server request"
-  "subjectAltName = " + (($ipAddresses.Split(',') | ForEach-Object { "IP:$_" }) -join ',') + ",DNS.1: $serverName" | Out-File extfile.cnf -Encoding Ascii
+  "subjectAltName = " + (($ipAddresses.Split(',') | ForEach-Object { "IP:$_" }) -join ',') + ",DNS.1:$serverName" | Out-File extfile.cnf -Encoding Ascii
   cat extfile.cnf
   & openssl x509 -req -days 365 -sha256 -in server.csr -CA $Global:caPublicKeyFile -passin $Global:caPrivateKeyPass -CAkey $Global:caPrivateKeyFile `
     -CAcreateserial -out server-cert.pem -extfile extfile.cnf

--- a/dockertls/run.ps1
+++ b/dockertls/run.ps1
@@ -1,0 +1,8 @@
+mkdir ~\.docker
+$ips = ((Get-NetIPAddress -AddressFamily IPv4).IPAddress) -Join ','
+docker container run --rm `
+  -e SERVER_NAME=$env:FQDN `
+  -e IP_ADDRESSES=$ips,$env:PUBIP `
+  -v "C:\ProgramData\docker:C:\ProgramData\docker" `
+  -v "$env:USERPROFILE\.docker:C:\Users\ContainerAdministrator\.docker" `
+  stefanscherer/dockertls-windows

--- a/dockertls/run.ps1
+++ b/dockertls/run.ps1
@@ -1,4 +1,6 @@
-mkdir ~\.docker
+if (!(Test-Path ~\.docker)) {
+  mkdir ~\.docker
+}
 $ips = ((Get-NetIPAddress -AddressFamily IPv4).IPAddress) -Join ','
 docker container run --rm `
   -e SERVER_NAME=$env:FQDN `


### PR DESCRIPTION
Had some minutes before DockerCon to add the serverName to the subjectAltName to make docker-compose work with the certs.

Tested it with the small `run.ps1` and two environment variables FQDN and PUBIP.

```powershell
if (!(Test-Path ~\.docker)) {
  mkdir ~\.docker
}
$ips = ((Get-NetIPAddress -AddressFamily IPv4).IPAddress) -Join ','
docker container run --rm `
  -e SERVER_NAME=$env:FQDN `
  -e IP_ADDRESSES=$ips,$env:PUBIP `
  -v "C:\ProgramData\docker:C:\ProgramData\docker" `
  -v "$env:USERPROFILE\.docker:C:\Users\ContainerAdministrator\.docker" `
  stefanscherer/dockertls-windows
```

Fixes #99