### PR TITLE
Use one script to update to Docker 17.05.0-rc1

### DIFF
--- a/mongo/3.4/build.ps1
+++ b/mongo/3.4/build.ps1
@@ -1,10 +1,4 @@
-Write-Host Updating Docker engine to master
-Stop-Service docker
-$wc = New-Object net.webclient
-$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/dockerd.exe", "$env:ProgramFiles\docker\dockerd.exe")
-$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/docker.exe", "$env:ProgramFiles\docker\docker.exe")
-Start-Service docker
-docker version
+. $PSScriptRoot\..\..\update-docker-rc.ps1
 
 Write-Host Building Mongo image for Nanoserver
 docker build -t mongo:nano -f Dockerfile .

--- a/node/build.ps1
+++ b/node/build.ps1
@@ -1,10 +1,4 @@
-Write-Host Updating Docker engine to master for PR docker/docker#31257
-Stop-Service docker
-$wc = New-Object net.webclient
-$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/dockerd.exe", "$env:ProgramFiles\docker\dockerd.exe")
-$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/docker.exe", "$env:ProgramFiles\docker\docker.exe")
-Start-Service docker
-docker version
+. $PSScriptRoot\..\update-docker-rc.ps1
 
 function buildVersion($majorMinorPatch, $majorMinor, $major) {
   docker build -t node:$majorMinorPatch $majorMinor

--- a/registry/build.ps1
+++ b/registry/build.ps1
@@ -1,10 +1,4 @@
-Write-Host Updating Docker engine to master
-Stop-Service docker
-$wc = New-Object net.webclient
-$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/dockerd.exe", "$env:ProgramFiles\docker\dockerd.exe")
-$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/docker.exe", "$env:ProgramFiles\docker\docker.exe")
-Start-Service docker
-docker version
+. $PSScriptRoot\..\update-docker-rc.ps1
 
 Write-Host Building registry binary and image
 docker build -t registry .

--- a/update-docker-rc.ps1
+++ b/update-docker-rc.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+Write-Host "Stopping docker service"
+Stop-Service docker
+$version = "17.05.0-ce-rc1"
+
+Write-Host "Downloading docker-$version.zip"
+$wc = New-Object net.webclient
+$wc.DownloadFile("https://test.docker.com/builds/Windows/x86_64/docker-$version.zip", "$env:TEMP\docker-$version.zip")
+Write-Host "Extracting docker-$version.zip"
+Expand-Archive -Path "$env:TEMP\docker-$version.zip" -DestinationPath $env:ProgramFiles -Force
+Remove-Item "$env:TEMP\docker-$version.zip"
+
+Write-Host "Starting docker service"
+Start-Service docker
+
+docker version

--- a/webserver/build.ps1
+++ b/webserver/build.ps1
@@ -1,9 +1,3 @@
-Write-Host Updating Docker engine to master
-Stop-Service docker
-$wc = New-Object net.webclient
-$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/dockerd.exe", "$env:ProgramFiles\docker\dockerd.exe")
-$wc.Downloadfile("https://master.dockerproject.org/windows/amd64/docker.exe", "$env:ProgramFiles\docker\docker.exe")
-Start-Service docker
-docker version
+. $PSScriptRoot\..\update-docker-rc.ps1
 
 docker build -t webserver .


### PR DESCRIPTION
Instead of using master (nightly) binaries, switch over to 17.05.0-rc1 binaries.
