### PR TITLE
Add test for golang/go#18555

### DIFF
--- a/golang-issue-18555/Dockerfile
+++ b/golang-issue-18555/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.8-windowsservercore
+WORKDIR /compile
+RUN git clone https://github.com/golang/go
+WORKDIR /compile/go/src
+ENV GOROOT_BOOTSTRAP C:/go
+ENV CGO_ENABLED 0
+RUN cmd /C all.bat
+RUN cp ..\bin\*.exe \go\bin

--- a/golang-issue-18555/Dockerfile
+++ b/golang-issue-18555/Dockerfile
@@ -1,8 +1,10 @@
 FROM golang:1.8-windowsservercore
-WORKDIR /compile
+RUN mv /go /go1.8.1
+WORKDIR /
 RUN git clone https://github.com/golang/go
-WORKDIR /compile/go/src
-ENV GOROOT_BOOTSTRAP C:/go
+WORKDIR /go/src
+ENV GOROOT_BOOTSTRAP C:/go1.8.1
 ENV CGO_ENABLED 0
-RUN cmd /C all.bat
-RUN cp ..\bin\*.exe \go\bin
+RUN git fetch https://go.googlesource.com/go refs/changes/34/41834/3 ; \
+    git checkout FETCH_HEAD
+RUN cmd /C make.bat

--- a/golang-issue-18555/README.md
+++ b/golang-issue-18555/README.md
@@ -1,0 +1,5 @@
+# Golang issue 18555
+
+This is a test for [golang/go#18555](https://github.com/golang/go/issues/18555): cmd/go: build inside a Windows container does not find the sources in mounted volume
+
+See if latest master branch fixes this issue. Let's test it on AppVeyor.

--- a/golang-issue-18555/build.ps1
+++ b/golang-issue-18555/build.ps1
@@ -1,0 +1,1 @@
+docker build -t golang-issue-18555 .

--- a/golang-issue-18555/test.ps1
+++ b/golang-issue-18555/test.ps1
@@ -6,5 +6,5 @@ Write-Host Current dir after running the go build:
 Write-Host The webserver dir after running the go build:
 dir ..\webserver
 if (!(Test-Path ..\webserver\webserver.exe)) {
-  Write-Error webserver.exe is missing, go build didn't work in container
+  Write-Error "webserver.exe is missing, go build didn't work in container"
 }

--- a/golang-issue-18555/test.ps1
+++ b/golang-issue-18555/test.ps1
@@ -1,0 +1,2 @@
+Write-Host Testing new golang image to build on volume mountpoint
+docker run -v "$(pwd)\..\webserver:C:\code" -w /code golang-issue-18555 go build webserver.go

--- a/golang-issue-18555/test.ps1
+++ b/golang-issue-18555/test.ps1
@@ -1,10 +1,12 @@
 Write-Host Testing new golang image to build on volume mountpoint
 Write-Host The webserver dir before running the go build:
 dir ..\webserver
+Write-Host Building a Go binary inside a container.
 docker run -v "$(pwd)\..\webserver:C:\code" -w /code golang-issue-18555 go build webserver.go
-Write-Host Current dir after running the go build:
 Write-Host The webserver dir after running the go build:
 dir ..\webserver
 if (!(Test-Path ..\webserver\webserver.exe)) {
-  Write-Error "webserver.exe is missing, go build didn't work in container"
+  Write-Error "webserver.exe is missing, go build didn't work in container."
+} else {
+  Write-Host "webserver.exe found, go build works in a container."
 }

--- a/golang-issue-18555/test.ps1
+++ b/golang-issue-18555/test.ps1
@@ -1,2 +1,10 @@
 Write-Host Testing new golang image to build on volume mountpoint
+Write-Host The webserver dir before running the go build:
+dir ..\webserver
 docker run -v "$(pwd)\..\webserver:C:\code" -w /code golang-issue-18555 go build webserver.go
+Write-Host Current dir after running the go build:
+Write-Host The webserver dir after running the go build:
+dir ..\webserver
+if (!(Test-Path ..\webserver\webserver.exe)) {
+  Write-Error webserver.exe is missing, go build didn't work in container
+}


### PR DESCRIPTION
Add test for golang/go#18555 to see if latest Go sources have a fix for compiling sources directly in a volume mountpoint.
