### PR TITLE
Read CADDY_VERSION from Dockerfile

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,6 +1,5 @@
 # escape=`
 FROM microsoft/nanoserver
-# note this version was a tagging mistake and the version  is usually referred to as 0.10 - https://github.com/mholt/caddy/releases/tag/v0.10.0
 ENV CADDY_VERSION 0.10.0
 RUN powershell -Command $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue'; `
     Invoke-WebRequest $('https://github.com/mholt/caddy/releases/download/v{0}/caddy_v{0}_windows_amd64.zip' -f $env:CADDY_VERSION) -OutFile 'caddy.zip' -UseBasicParsing ; `

--- a/caddy/build.ps1
+++ b/caddy/build.ps1
@@ -1,1 +1,2 @@
-docker build -t caddy:0.10 .
+$version=$(select-string -Path Dockerfile -Pattern "ENV CADDY_VERSION").ToString().split()[-1]
+docker build -t caddy:$version .

--- a/caddy/push.ps1
+++ b/caddy/push.ps1
@@ -1,4 +1,5 @@
-docker tag caddy:0.10 stefanscherer/caddy-windows:0.10
-docker tag caddy:0.10 stefanscherer/caddy-windows:latest
-docker push stefanscherer/caddy-windows:0.10
+$version=$(select-string -Path Dockerfile -Pattern "ENV CADDY_VERSION").ToString().split()[-1]
+docker tag caddy:$version stefanscherer/caddy-windows:$version
+docker tag caddy:$version stefanscherer/caddy-windows:latest
+docker push stefanscherer/caddy-windows:$version
 docker push stefanscherer/caddy-windows:latest

--- a/caddy/test.ps1
+++ b/caddy/test.ps1
@@ -1,4 +1,5 @@
-docker run --name caddy -d -p 8080:80 -v "$(pwd)\conf:C:\caddy\conf" -v "$(pwd)\www:C:\wwwroot" caddy:0.10
+$version=$(select-string -Path Dockerfile -Pattern "ENV CADDY_VERSION").ToString().split()[-1]
+docker run --name caddy -d -p 8080:80 -v "$(pwd)\conf:C:\caddy\conf" -v "$(pwd)\www:C:\wwwroot" caddy:$version
 Start-Sleep -Seconds 5
 $req = Invoke-WebRequest http://$(docker inspect -f '{{ .NetworkSettings.Networks.nat.IPAddress }}' caddy) -UseBasicParsing
 $code = $req.statuscode


### PR DESCRIPTION
For easier maintenance, read the CADDY_VERSION From Dockerfile so we only have to update one place for new caddy versions.
