### PR TITLE
Build devel version of Golang to test fix for #18555

### DIFF
--- a/golang/Dockerfile.devel
+++ b/golang/Dockerfile.devel
@@ -1,6 +1,20 @@
-FROM golang:1.8-nanoserver
+FROM golang:1.8-windowsservercore AS build
+RUN mv /go /go1.8.1
+WORKDIR /
+RUN git clone https://github.com/golang/go
+WORKDIR /go/src
+ENV GOROOT_BOOTSTRAP C:/go1.8.1
+ENV CGO_ENABLED 0
+RUN cmd /C make.bat
 
+FROM microsoft/nanoserver
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+ENV GOPATH C:\\gopath
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+  Write-Host ('Updating PATH: {0}' -f $newPath); \
+  setx /M PATH $newPath;
+COPY --from=build /go /go
+WORKDIR $GOPATH
 
 ENV GIT_VERSION 2.12.2
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/v${GIT_VERSION}.windows.2/MinGit-${GIT_VERSION}.2-64-bit.zip

--- a/golang/build.ps1
+++ b/golang/build.ps1
@@ -1,2 +1,4 @@
+. $PSScriptRoot\..\update-docker-ce.ps1
+
 docker build -t golang .
 docker build -t golang:devel -f Dockerfile.devel .

--- a/golang/build.ps1
+++ b/golang/build.ps1
@@ -1,1 +1,2 @@
 docker build -t golang .
+docker build -t golang:devel -f Dockerfile.devel .

--- a/golang/push.ps1
+++ b/golang/push.ps1
@@ -2,3 +2,6 @@ docker tag golang stefanscherer/golang-windows:1.8
 docker tag golang stefanscherer/golang-windows
 docker push stefanscherer/golang-windows:1.8
 docker push stefanscherer/golang-windows
+
+docker tag golang:devel stefanscherer/golang-windows:devel
+docker push stefanscherer/golang-windows:devel

--- a/golang/test.ps1
+++ b/golang/test.ps1
@@ -1,2 +1,7 @@
+Write-Host Testing golang image
 docker run golang go version
 docker run golang git --version
+
+Write-Host Testing golang:devel image
+docker run golang:devel go version
+docker run golang:devel git --version


### PR DESCRIPTION
After golang/go#18555 got fixed with https://github.com/golang/go/commit/53003621720ff39c4745a76f76847123c27b01ea let's build a Windows Docker image with golang built from master.

Images are available on the Docker Hub:

* stefanscherer/golang-windows:1.8, stefanscherer/golang-windows:latest
* stefanscherer/golang-windows:devel
