### PR TITLE
[Enhancement] Add support for multiple dns names in the SAN of the generated certificate.

### DIFF
--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -31,7 +31,7 @@ function createCA(){
 }
 
 # https://docs.docker.com/engine/security/https/
-function createCerts($serverCertsPath, $serverName, $ipAddresses, $clientCertsPath) {
+function createCerts($serverCertsPath, $serverName, $additionalServerNames, $ipAddresses, $clientCertsPath) {
   Write-Host "`n=== Reading in CA Private Key Password"
   $Global:caPrivateKeyPass = Get-Content -Path $Global:caPrivateKeyPassFile
 
@@ -172,6 +172,7 @@ function createMachineConfig ($machineName, $machineHome, $machinePath, $machine
 
 $dockerData = "$env:ProgramData\docker"
 $serverName = $env:SERVER_NAME
+$additionalNames = $env:ADDITIONAL_NAMES
 $ipAddresses = $env:IP_ADDRESSES
 $userPath = "$env:USERPROFILE\.docker"
 
@@ -186,7 +187,7 @@ if (  !(Test-Path -Path $Global:caPrivateKeyPassFile) -or
   createCA
 }
 
-createCerts "$dockerData\certs.d" $serverName $ipAddresses "$userPath"
+createCerts "$dockerData\certs.d" $serverName $additionalNames $ipAddresses "$userPath"
 updateConfig "$dockerData\config\daemon.json" "$dockerData\certs.d"
 
 $machineHome = $env:MACHINE_HOME

--- a/dockertls/run.ps1
+++ b/dockertls/run.ps1
@@ -1,10 +1,17 @@
+param(
+  $ServerName = $env:FQDN,
+  $IPAddresses = $env:PUBIP,
+  $AlternativeNames = $env:ALTNAMES
+)
+
 if (!(Test-Path ~\.docker)) {
   mkdir ~\.docker
 }
 $ips = ((Get-NetIPAddress -AddressFamily IPv4).IPAddress) -Join ','
 docker container run --rm `
-  -e SERVER_NAME=$env:FQDN `
-  -e IP_ADDRESSES=$ips,$env:PUBIP `
+  -e SERVER_NAME=$ServerName `
+  -e IP_ADDRESSES=$ips,$IPAddresses `
+  -e ALTERNATIVE_NAMES=$AlternativeNames `
   -v "C:\ProgramData\docker:C:\ProgramData\docker" `
   -v "$env:USERPROFILE\.docker:C:\Users\ContainerAdministrator\.docker" `
   stefanscherer/dockertls-windows

--- a/dockertls/test.ps1
+++ b/dockertls/test.ps1
@@ -1,3 +1,3 @@
 $ErrorActionPreference = 'SilentlyContinue';
-docker run --rm -e SERVER_NAME=test -e IP_ADDRESSES=127.0.0.1 dockertls 2>&1
+docker run --rm -e SERVER_NAME=test -e IP_ADDRESSES=127.0.0.1 -e ALTERNATIVE_NAMES=test.local,master.foo.bar dockertls 2>&1
 $ErrorActionPreference = 'Stop';


### PR DESCRIPTION
**Use Case:**
WHEN a common DNS name exists for all managers in a swarm (e.g. manager.nonprod.blah.io)
AND each node must support communication using the following DNS name examples
COMPUTERNAME
COMPUTERNAME.ACTIVE_DIRECTORY_DOMAIN
manager.nonprod.blah.io
AND each node in the swarm has DockerTLS enabled using the stefanscherer/dockertls-windows image
THEN `dockerhost -H COMPUTERNAME ps` should execute successfully
AND `dockerhost -H COMPUTERNAME.ACTIVE_DIRECTORY_DOMAIN ps` should execute successfully
AND `dockerhost -H manager.nonprod.blah.io ps` should execute successfully.

**Changes Made**
- Added an environment variable, named `ALTERNATIVE_NAMES`, to supply a comma-delimited list of alternative names.
- Refactored logic that generated Subject Alternative Names to support generation of multiple DNS alternative names from a comma separated list.
- Refactored run.ps1 to support taking parameters in addition to environment variables.

#182 