### PR TITLE
Add support for a custom Docker Data-Root directory.  Update readme.md.

### DIFF
--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -123,7 +123,7 @@ docker run --rm `
   -e SERVER_NAME=$(hostname) `
   -e DOCKER_DATA_ROOT=E:\ProgramData\Docker `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
-  -v "c:\programdata\docker:c:\programdata\docker" `
+  -v "E:\ProgramData\Docker:c:\programdata\docker" `
   -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
 ```
 

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -114,11 +114,28 @@ docker run --rm `
 ```
 
 ### Using an alternate Docker Data-Root directory in the daemon.json configuration file.
+
+If you have configured `dockerd` to start with the `--data-root <Path>` option, you need to provide that path to ensure the daemon.json file gets written correctly.
+
 ```powershell
 mkdir $env:USERPROFILE\.docker
 docker run --rm `
   -e SERVER_NAME=$(hostname) `
   -e DOCKER_DATA_ROOT=E:\ProgramData\Docker `
+  -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
+  -v "c:\programdata\docker:c:\programdata\docker" `
+  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+```
+
+### Providing additional Subject Alternative Names the Docker TLS certificate will accept.
+
+Sometimes it is necessary to provide additional dns names the certificate will be valid for, these might include the fully qualified domain name (e.g. computer.corporate.domain.com) or an alternative name that might resolve to multiple hosts (e.g manager.corporate.domain.com).  You can provide these names in a comma separated list through the `ALTERNATIVE_NAMES` environment variable.
+
+```powershell
+mkdir $env:USERPROFILE\.docker
+docker run --rm `
+  -e SERVER_NAME=$(hostname) `
+  -e "ALTERNATIVE_NAMES=$(HostName).$((Get-WmiObject win32_computersystem).Domain),manager.$((Get-WmiObject win32_computersystem).Domain)" `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
   -v "c:\programdata\docker:c:\programdata\docker" `
   -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -118,7 +118,7 @@ docker run --rm `
 mkdir $env:USERPROFILE\.docker
 docker run --rm `
   -e SERVER_NAME=$(hostname) `
-  -e DockerDataRoot=E:\ProgramData\Docker `
+  -e DOCKER_DATA_ROOT=E:\ProgramData\Docker `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
   -v "c:\programdata\docker:c:\programdata\docker" `
   -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -113,6 +113,17 @@ docker run --rm `
   -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
 ```
 
+### Using an alternate Docker Data-Root directory in the daemon.json configuration file.
+```powershell
+mkdir $env:USERPROFILE\.docker
+docker run --rm `
+  -e SERVER_NAME=$(hostname) `
+  -e DockerDataRoot=E:\ProgramData\Docker `
+  -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
+  -v "c:\programdata\docker:c:\programdata\docker" `
+  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+```
+
 ## See also
 
 * [Dockerfile](https://github.com/StefanScherer/dockerfiles-windows/blob/master/dockertls/Dockerfile)

--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -186,6 +186,12 @@ function createMachineConfig ($machineName, $machineHome, $machinePath, $machine
 }
 
 $dockerData = "$env:ProgramData\docker"
+$dockerDataRoot = $dockerData
+if (-not [string]::IsNullOrWhiteSpace($env:DockerDataRoot))
+{
+	$dockerDataRoot = $env:DockerDataRoot
+}
+
 $serverName = $env:SERVER_NAME
 $alternativeNames = $env:ALTERNATIVE_NAMES
 $ipAddresses = $env:IP_ADDRESSES
@@ -203,7 +209,7 @@ if (  !(Test-Path -Path $Global:caPrivateKeyPassFile) -or
 }
 
 createCerts "$dockerData\certs.d" $serverName $alternativeNames $ipAddresses "$userPath"
-updateConfig "$dockerData\config\daemon.json" "$dockerData\certs.d"
+updateConfig "$dockerData\config\daemon.json" "$dockerDataRoot\certs.d"
 
 $machineHome = $env:MACHINE_HOME
 $machineName = $env:MACHINE_NAME

--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -187,9 +187,9 @@ function createMachineConfig ($machineName, $machineHome, $machinePath, $machine
 
 $dockerData = "$env:ProgramData\docker"
 $dockerDataRoot = $dockerData
-if (-not [string]::IsNullOrWhiteSpace($env:DockerDataRoot))
+if (-not [string]::IsNullOrWhiteSpace($env:DOCKER_DATA_ROOT))
 {
-	$dockerDataRoot = $env:DockerDataRoot
+	$dockerDataRoot = $env:DOCKER_DATA_ROOT
 }
 
 $serverName = $env:SERVER_NAME


### PR DESCRIPTION
I have run into a scenario where I have `dockerd` configured with the `--data-root <Path>` option.  When I run this container to secure my site I am unable to restart docker until I edit the paths of the certificate in the daemon.json file.

This change adds support to provide a custom Docker Data root path for writing into the configuration file.

This change also adds missing documentation for the ALTERNATIVE_NAMES environment variable.
