### PR TITLE
Add build-tools image

### DIFF
--- a/node/8.6/README.md
+++ b/node/8.6/README.md
@@ -2,6 +2,12 @@
 
 A Windows Server Core Docker container image with Node.js 8.6.0 installed.
 
+## Images
+
+- stefanscherer/node-windows:8.6.0 -> Windows Server Core + Node + NPM + Yarn
+- stefanscherer/node-windows:8.6.0-build-tools -> + Python + C++ build tools
+- stefanscherer/node-windows:8.6.0-nano -> Nano Server + Node + NPM + Yarn
+
 ## Building
 
 ```

--- a/node/8.6/build-tools/Dockerfile
+++ b/node/8.6/build-tools/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:8.6.0-windowsservercore
+
+RUN npm install --global windows-build-tools

--- a/node/build.ps1
+++ b/node/build.ps1
@@ -6,6 +6,12 @@ function buildVersion($majorMinorPatch, $majorMinor, $major) {
   docker tag node:$majorMinorPatch node:$major
   docker tag node:$majorMinorPatch node:$majorMinorPatch-windowsservercore
 
+  if (Test-Path $majorMinor\build-tools) {
+    docker build -t node:$majorMinorPatch-build-tools $majorMinor/build-tools
+    docker tag node:$majorMinorPatch-build-tools node:$majorMinor-build-tools
+    docker tag node:$majorMinorPatch-build-tools node:$major-build-tools
+  }
+
   docker build -t node:$majorMinorPatch-onbuild $majorMinor/onbuild
   docker tag node:$majorMinorPatch-onbuild node:$majorMinor-onbuild
   docker tag node:$majorMinorPatch-onbuild node:$major-onbuild

--- a/node/push.ps1
+++ b/node/push.ps1
@@ -15,6 +15,12 @@ function pushVersion($majorMinorPatch, $majorMinor, $major) {
   docker tag node:$majorMinor-nano-onbuild stefanscherer/node-windows:$majorMinor-nano-onbuild
   docker tag node:$major-nano-onbuild stefanscherer/node-windows:$major-nano-onbuild
 
+  if (Test-Path $majorMinor\build-tools) {
+    docker tag node:$majorMinorPatch-build-tools stefanscherer/node-windows:$majorMinorPatch-build-tools
+    docker tag node:$majorMinorPatch-build-tools stefanscherer/node-windows:$majorMinor-build-tools
+    docker tag node:$majorMinorPatch-build-tools stefanscherer/node-windows:$major-build-tools
+  }
+
   docker push stefanscherer/node-windows:$majorMinorPatch
   docker push stefanscherer/node-windows:$majorMinor
   docker push stefanscherer/node-windows:$major
@@ -27,6 +33,12 @@ function pushVersion($majorMinorPatch, $majorMinor, $major) {
   docker push stefanscherer/node-windows:$majorMinorPatch-nano-onbuild
   docker push stefanscherer/node-windows:$majorMinor-nano-onbuild
   docker push stefanscherer/node-windows:$major-nano-onbuild
+
+  if (Test-Path $majorMinor\build-tools) {
+    docker push stefanscherer/node-windows:$majorMinorPatch-build-tools
+    docker push stefanscherer/node-windows:$majorMinor-build-tools
+    docker push stefanscherer/node-windows:$major-build-tools
+  }
 }
 
 pushVersion "6.11.3" "6.11" "6"


### PR DESCRIPTION
Add a Node.js image with the Windows build tools installed.

With a multi-stage build you then can install NPM dependencies and even compile native bindings.

```Dockerfile
FROM stefanscherer/node-windows:8.6.0-build-tools
WORKDIR /code
COPY package.json package.json
RUN npm install
COPY . .

FROM stefanscherer/node-windows:8.6.0-nano
COPY --from=0 /code /code
WORKDIR /code
ENTRYPOINT ["node.exe", "app.js]
```
