### PR TITLE
Minimize curl + 1709 version

### DIFF
--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -1,12 +1,8 @@
+FROM microsoft/nanoserver:10.0.14393.1770 AS download
+ENV CURL_VERSION 7.56.1
+WORKDIR /curl
+ADD https://skanthak.homepage.t-online.de/download/curl-$CURL_VERSION.cab curl.cab
+RUN expand /R curl.cab /F:* .
 FROM microsoft/nanoserver:10.0.14393.1770
-
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
-ENV CURL_VERSION 7.55.1
-
-RUN Invoke-WebRequest $('https://dl.uxnr.de/build/curl/curl_winssl_msys2_mingw64_stc/curl-{0}/curl-{0}.zip' -f $env:CURL_VERSION) -OutFile 'curl.zip' -UseBasicParsing ; \
-    Expand-Archive curl.zip -DestinationPath C:\ ; \
-    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord ; \
-    Remove-Item -Path curl.zip
-
-ENTRYPOINT [ "C:\\src\\curl.exe" ]
+COPY --from=download /curl/AMD64/ /Windows/system32/
+COPY --from=download /curl/CURL.LIC /

--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -6,3 +6,4 @@ RUN expand /R curl.cab /F:* .
 FROM microsoft/nanoserver:10.0.14393.1770
 COPY --from=download /curl/AMD64/ /Windows/system32/
 COPY --from=download /curl/CURL.LIC /
+ENTRYPOINT ["curl.exe"]

--- a/curl/Dockerfile.1709
+++ b/curl/Dockerfile.1709
@@ -5,3 +5,4 @@ RUN expand /R curl.cab /F:* .
 FROM microsoft/nanoserver:1709
 COPY --from=download /curl/AMD64/ /Windows/system32/
 COPY --from=download /curl/CURL.LIC /
+ENTRYPOINT ["curl.exe"]

--- a/curl/Dockerfile.1709
+++ b/curl/Dockerfile.1709
@@ -1,0 +1,7 @@
+FROM microsoft/nanoserver:1709 AS download
+WORKDIR /curl
+ADD https://skanthak.homepage.t-online.de/download/curl-7.56.1.cab curl.cab
+RUN expand /R curl.cab /F:* .
+FROM microsoft/nanoserver:1709
+COPY --from=download /curl/AMD64/ /Windows/system32/
+COPY --from=download /curl/CURL.LIC /

--- a/curl/README.md
+++ b/curl/README.md
@@ -1,6 +1,6 @@
 # curl
 [![This image on DockerHub](https://img.shields.io/docker/pulls/stefanscherer/curl-windows.svg)](https://hub.docker.com/r/stefanscherer/curl-windows/)
 
-curl in a Windows container
+curl in a Windows NanoServer container
 
-Sometimes I need `curl.exe` inside a Container to test inter-container networking. Here is a Docker image for it.
+Sometimes I need `curl.exe` inside a Windows NanoServer container to test inter-container networking. Here is a Docker image for it.

--- a/curl/push.ps1
+++ b/curl/push.ps1
@@ -3,3 +3,7 @@ docker tag curl stefanscherer/curl-windows
 docker tag curl stefanscherer/curl-windows:$version
 docker push stefanscherer/curl-windows:$version
 docker push stefanscherer/curl-windows
+
+npm install -g rebase-docker-image
+rebase-docker-image stefanscherer/curl-windows:$version -t stefanscherer/curl-windows:$version-1709 -b microsoft/nanoserver:1709
+rebase-docker-image stefanscherer/curl-windows:$version -t stefanscherer/curl-windows:1709 -b microsoft/nanoserver:1709


### PR DESCRIPTION
Create a minimal curl image based in microsoft/nanoserver.

And rebase it to 1709 to have a nanoserver:1709 image + curl to download things without PowerShell.