### PR TITLE
Create multi-os curl image

### DIFF
--- a/curl/Dockerfile.1709
+++ b/curl/Dockerfile.1709
@@ -1,8 +1,0 @@
-FROM microsoft/nanoserver:1709 AS download
-WORKDIR /curl
-ADD https://skanthak.homepage.t-online.de/download/curl-7.56.1.cab curl.cab
-RUN expand /R curl.cab /F:* .
-FROM microsoft/nanoserver:1709
-COPY --from=download /curl/AMD64/ /Windows/system32/
-COPY --from=download /curl/CURL.LIC /
-ENTRYPOINT ["curl.exe"]

--- a/curl/README.md
+++ b/curl/README.md
@@ -4,3 +4,10 @@
 curl in a Windows NanoServer container
 
 Sometimes I need `curl.exe` inside a Windows NanoServer container to test inter-container networking. Here is a Docker image for it.
+
+It is a multi-os Docker image so you can run it on Windows Server 2016 LTS as well as on Windows Server 1709.
+
+```
+docker run stefanscherer/curl-windows
+```
+

--- a/curl/manifest.yml
+++ b/curl/manifest.yml
@@ -1,0 +1,13 @@
+image: stefanscherer/curl-windows:7.56.1
+tags: ['7.56', '7', 'latest']
+manifests:
+  -
+    image: stefanscherer/curl-windows:7.56.1-2016
+    platform:
+      architecture: amd64
+      os: windows
+  -
+    image: stefanscherer/curl-windows:7.56.1-1709
+    platform:
+      architecture: amd64
+      os: windows

--- a/curl/push.ps1
+++ b/curl/push.ps1
@@ -1,9 +1,9 @@
 $version=$(select-string -Path Dockerfile -Pattern "ENV CURL_VERSION").ToString().split()[-1]
-docker tag curl stefanscherer/curl-windows
-docker tag curl stefanscherer/curl-windows:$version
-docker push stefanscherer/curl-windows:$version
-docker push stefanscherer/curl-windows
+docker tag curl stefanscherer/curl-windows:$version-2016
+docker push stefanscherer/curl-windows:$version-2016
 
 npm install -g rebase-docker-image
-rebase-docker-image stefanscherer/curl-windows:$version -t stefanscherer/curl-windows:$version-1709 -b microsoft/nanoserver:1709
-rebase-docker-image stefanscherer/curl-windows:$version -t stefanscherer/curl-windows:1709 -b microsoft/nanoserver:1709
+rebase-docker-image stefanscherer/curl-windows:$version-2016 -t stefanscherer/curl-windows:$version-1709 -b microsoft/nanoserver:1709
+
+choco install -y manifest-tool
+manifest-tool push from-spec manifest.yml


### PR DESCRIPTION
Create a manifest list with both Windows versions

```
docker run stefanscherer/curl-windows
```

Works on Windows Server 2016 LTSC and 1709 picking the right image without the need of a HyperV container.
