### PR TITLE
Improve Node.js tests running commands in container

### DIFF
--- a/node/test.ps1
+++ b/node/test.ps1
@@ -1,12 +1,25 @@
+function testCommand($image, $command, $expected) {
+  Write-Host "Testing docker image $image with command $command"
+  $ErrorActionPreference = 'SilentlyContinue';
+  $actual = $(docker run $image $command)
+  $ErrorActionPreference = 'Stop';
+  if ($LastExitCode) {
+    Write-Error "Command exited with error $LastExitCode"
+  }
+  if ($expected -and ($actual -ne $expected)) {
+    Write-Error "Expected '$expected', but got '$actual'"
+  }
+  if ($actual -eq "") {
+    Write-Error "Expected some output, but got '$actual'"
+  }
+}
+
 function testVersion($majorMinorPatch) {
-  docker run node:$majorMinorPatch-windowsservercore node --version
-  $ErrorActionPreference = 'SilentlyContinue';
-  docker run node:$majorMinorPatch-windowsservercore npm.cmd --version
-  $ErrorActionPreference = 'Stop';
-  docker run node:$majorMinorPatch-nanoserver node --version
-  $ErrorActionPreference = 'SilentlyContinue';
-  docker run node:$majorMinorPatch-nanoserver npm.cmd --version
-  $ErrorActionPreference = 'Stop';
+  testCommand "node:$majorMinorPatch-windowsservercore" "node --version" "v$majorMinorPatch"
+  testCommand "node:$majorMinorPatch-windowsservercore" "npm.cmd --version" ""
+
+  testCommand "node:$majorMinorPatch-nanoserver" "node --version" "v$majorMinorPatch"
+  testCommand "node:$majorMinorPatch-nanoserver" "npm.cmd --version" ""
 }
 
 testVersion "6.11.5"

--- a/node/test.ps1
+++ b/node/test.ps1
@@ -1,7 +1,7 @@
 function testCommand($image, $command, $expected) {
-  Write-Host "Testing docker image $image with command $command"
+  Write-Host "Testing docker image $image with command $command --version"
   $ErrorActionPreference = 'SilentlyContinue';
-  $actual = $(docker run $image $command)
+  $actual = $(docker run $image $command --version)
   $ErrorActionPreference = 'Stop';
   if ($LastExitCode) {
     Write-Error "Command exited with error $LastExitCode"
@@ -15,11 +15,11 @@ function testCommand($image, $command, $expected) {
 }
 
 function testVersion($majorMinorPatch) {
-  testCommand "node:$majorMinorPatch-windowsservercore" "node --version" "v$majorMinorPatch"
-  testCommand "node:$majorMinorPatch-windowsservercore" "npm.cmd --version" ""
+  testCommand "node:$majorMinorPatch-windowsservercore" "node" "v$majorMinorPatch"
+  testCommand "node:$majorMinorPatch-windowsservercore" "npm.cmd" ""
 
-  testCommand "node:$majorMinorPatch-nanoserver" "node --version" "v$majorMinorPatch"
-  testCommand "node:$majorMinorPatch-nanoserver" "npm.cmd --version" ""
+  testCommand "node:$majorMinorPatch-nanoserver" "node" "v$majorMinorPatch"
+  testCommand "node:$majorMinorPatch-nanoserver" "npm.cmd" ""
 }
 
 testVersion "6.11.5"

--- a/node/test.ps1
+++ b/node/test.ps1
@@ -1,8 +1,9 @@
 function testCommand($image, $command, $expected) {
-  Write-Host "Testing docker image $image with command $command --version"
+  Write-Host "Testing: docker run $image $command --version"
   $ErrorActionPreference = 'SilentlyContinue';
   $actual = $(docker run $image $command --version)
   $ErrorActionPreference = 'Stop';
+  Write-Host $actual
   if ($LastExitCode) {
     Write-Error "Command exited with error $LastExitCode"
   }


### PR DESCRIPTION
* Check for exit code of node and npm command
* Check for expected node version string
* Check at least that output of npm is not empty

This helps to find problems in nanoserver earlier, see nodejs/node/issues/16603
