### PR TITLE
Update Docker CLI 17.10.0-ce

### DIFF
--- a/docker-cli/Dockerfile
+++ b/docker-cli/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/nanoserver:10.0.14393.1770
+FROM microsoft/nanoserver:10.0.14393.1770 as download
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV DOCKER_VERSION 17.07.0-ce
+ENV DOCKER_VERSION 17.10.0-ce
 
 RUN Invoke-WebRequest $('https://download.docker.com/win/static/edge/x86_64/docker-{0}.zip' -f $env:DOCKER_VERSION) -OutFile 'docker.zip' -UseBasicParsing ; \
     Expand-Archive docker.zip -DestinationPath C:\ ; \
@@ -11,4 +11,6 @@ RUN Invoke-WebRequest $('https://download.docker.com/win/static/edge/x86_64/dock
     Remove-Item -Path docker.zip ; \
     Remove-Item -Path docker\dockerd.exe
 
+FROM microsoft/nanoserver:10.0.14393.1770
+COPY --from=download docker/docker.exe /
 CMD [ "docker.exe" ]

--- a/docker-cli/README.md
+++ b/docker-cli/README.md
@@ -1,0 +1,10 @@
+# Docker CLI
+[![This image on DockerHub](https://img.shields.io/docker/pulls/stefanscherer/docker-cli-windows.svg)](https://hub.docker.com/r/stefanscherer/docker-cli-windows/)
+
+To test the Docker API from inside a Windows container it sometimes is useful to have the Docker CLI.
+
+Especially for Windows Server 1709 it's easy to access the Docker API of the host
+
+```
+docker run -v //./pipe/docker_engine://./pipe/docker_engine -u ContainerAdministrator stefanscherer/docker-cli-windows docker version
+```

--- a/docker-cli/build.ps1
+++ b/docker-cli/build.ps1
@@ -1,2 +1,1 @@
 docker build -t docker-cli .
-docker tag docker-cli:latest docker-cli:1.13.0

--- a/docker-cli/push.ps1
+++ b/docker-cli/push.ps1
@@ -1,4 +1,20 @@
-docker tag docker-cli:1.13.0 stefanscherer/docker-cli-windows:1.13.0
-docker tag docker-cli:1.13.0 stefanscherer/docker-cli-windows:latest
-docker push stefanscherer/docker-cli-windows:1.13.0
-docker push stefanscherer/docker-cli-windows:latest
+$version=$(select-string -Path Dockerfile -Pattern "ENV DOCKER_VERSION").ToString().split()[-1]
+docker tag docker-cli stefanscherer/docker-cli-windows:$version-2016
+docker push stefanscherer/docker-cli-windows:$version-2016
+
+npm install -g rebase-docker-image
+rebase-docker-image stefanscherer/docker-cli-windows:$version-2016 -t stefanscherer/docker-cli-windows:$version-1709 -b microsoft/nanoserver:1709
+
+Invoke-WebRequest -UseBasicParsing https://6582-88013053-gh.circle-artifacts.com/0/work/build/docker-windows-amd64 -OutFile docker.exe
+
+.\docker.exe manifest create `
+  stefanscherer/docker-cli-windows:$version `
+  stefanscherer/docker-cli-windows:$version-2016 `
+  stefanscherer/docker-cli-windows:$version-1709
+.\docker.exe manifest push stefanscherer/docker-cli-windows:$version
+
+.\docker.exe manifest create `
+  stefanscherer/docker-cli-windows:latest `
+  stefanscherer/docker-cli-windows:$version-2016 `
+  stefanscherer/docker-cli-windows:$version-1709
+.\docker.exe manifest push stefanscherer/docker-cli-windows:latest


### PR DESCRIPTION
* Update Docker CLI 17.10.0-ce
* Build multi-os image for Windows Server 2016 + Windows Server 1709

Example for Windows Server 1709:

```
docker run -v //./pipe/docker_engine://./pipe/docker_engine -u ContainerAdministrator stefanscherer/docker-cli-windows docker version
```
