### PR TITLE
Update Traefik 1.4.2

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/nanoserver:10.0.14393.1770
 
-ENV TRAEFIK_VERSION 1.4.0
+ENV TRAEFIK_VERSION 1.4.2
 
 ADD https://github.com/containous/traefik/releases/download/v${TRAEFIK_VERSION}/traefik_windows-amd64 /traefik.exe
 


### PR DESCRIPTION
Update Traefik 1.4.2


No multi-os image as traefik.exe does not work in insider and 1709 nanoserver image as netapi32.dll is missing. Golang has to be fixed https://github.com/golang/go/issues/21867 
