### PR TITLE
Fix docker containers for Oracle Java running in NanoServer/WindowsSe…

### DIFF
--- a/java/oracle/README.md
+++ b/java/oracle/README.md
@@ -10,9 +10,33 @@ Build it:
 
 ```
 $ cd java-8
+$ tar xzf server-jre-8u152-windows-x64.tar.gz
 $ docker build -t oracle/serverjre:8-windowsservercore -f windowsservercore/Dockerfile .
 $ docker build -t oracle/serverjre:8-nanoserver -f nanoserver/Dockerfile .
 ```
+
+Run nanoserver container instance:
+
+```
+$ docker create -t --name 8-nanoserver -i oracle/serverjre:8-nanoserver
+$ docker start -i 8-nanoserver
+```
+
+Run windows server core container instance:
+
+```
+$ docker create -t --name 8-windowsservercore -i oracle/serverjre:8-windowsservercore
+$ docker start -i 8-windowsservercore
+```
+
+Test in the running container instances
+
+```
+java -version
+```
+
+
+
 
 ## Java 7
 [Download Server JRE 7](http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html#sjre-7u80-oth-JPR) `.tar.gz` file and drop it inside folder `java-7`. You also have to extract all files as there are issues adding the `tar.gz` file directly.
@@ -23,4 +47,24 @@ $ cd java-7
 $ tar xzf server-jre-7u80-windows-x64.tar.gz
 $ docker build -t oracle/serverjre:7-windowsservercore -f windowsservercore/Dockerfile .
 $ docker build -t oracle/serverjre:7-nanoserver -f nanoserver/Dockerfile .
+```
+
+Run nanoserver container instance:
+
+```
+$ docker create -t --name 7-nanoserver -i oracle/serverjre:7-nanoserver
+$ docker start -i 7-nanoserver
+```
+
+Run windows server core container instance:
+
+```
+$ docker create -t --name 7-windowsservercore -i oracle/serverjre:7-windowsservercore
+$ docker start -i 7-windowsservercore
+```
+
+Test in the running container instances
+
+```
+java -version
 ```

--- a/java/oracle/java-7/nanoserver/Dockerfile
+++ b/java/oracle/java-7/nanoserver/Dockerfile
@@ -3,6 +3,6 @@ FROM microsoft/nanoserver:latest
 ENV JAVA_PKG=jdk1.7.0_80/ \
     JAVA_HOME=C:\\jdk1.7.0_80
 
-ADD $JAVA_PKG /
+ADD $JAVA_PKG $JAVA_HOME
 
 RUN setx /M PATH %PATH%;%JAVA_HOME%\bin

--- a/java/oracle/java-7/windowsservercore/Dockerfile
+++ b/java/oracle/java-7/windowsservercore/Dockerfile
@@ -3,6 +3,6 @@ FROM microsoft/windowsservercore:latest
 ENV JAVA_PKG=jdk1.7.0_80/ \
     JAVA_HOME=C:\\jdk1.7.0_80
 
-ADD $JAVA_PKG /
+ADD $JAVA_PKG $JAVA_HOME
 
 RUN setx /M PATH %PATH%;%JAVA_HOME%\bin

--- a/java/oracle/java-8/nanoserver/Dockerfile
+++ b/java/oracle/java-8/nanoserver/Dockerfile
@@ -1,8 +1,8 @@
 FROM microsoft/nanoserver:latest
 
-ENV JAVA_PKG=server-jre-8u112-windows-x64.tar.gz \
-    JAVA_HOME=C:\\jdk1.8.0_112
+ENV JAVA_PKG=jdk1.8.0_152/ \
+    JAVA_HOME=C:\\jdk1.8.0_152
 
-ADD $JAVA_PKG /
+ADD $JAVA_PKG $JAVA_HOME
 
 RUN setx /M PATH %PATH%;%JAVA_HOME%\bin

--- a/java/oracle/java-8/windowsservercore/Dockerfile
+++ b/java/oracle/java-8/windowsservercore/Dockerfile
@@ -1,8 +1,8 @@
 FROM microsoft/windowsservercore:latest
 
-ENV JAVA_PKG=server-jre-8u112-windows-x64.tar.gz \
-    JAVA_HOME=C:\\jdk1.8.0_112
+ENV JAVA_PKG=jdk1.8.0_152/ \
+    JAVA_HOME=C:\\jdk1.8.0_152
 
-ADD $JAVA_PKG /
+ADD $JAVA_PKG $JAVA_HOME
 
 RUN setx /M PATH %PATH%;%JAVA_HOME%\bin


### PR DESCRIPTION
…rverCore ..  It was incorrectly copying java folder contents to root drive. Also improved the documentation for first timers