### PR TITLE
Use MinGit to make git work in mapped volumes

### DIFF
--- a/git-for-windows-issue/Dockerfile
+++ b/git-for-windows-issue/Dockerfile
@@ -1,20 +1,10 @@
-FROM microsoft/windowsservercore:10.0.14393.1770
+FROM microsoft/nanoserver:10.0.14393.2007
 
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+ENV GIT_VERSION 2.15.1
+ENV GIT_PATCH_VERSION 2
 
-ENV chocolateyUseWindowsCompression false
-
-RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
-    choco install -y git -params "/GitAndUnixToolsOnPath"
-
-RUN git --version --build-options
-RUN cmd.exe /c ver
-RUN type 'C:\Program Files\Git\etc\install-options.txt'
-
-# these install-options.txt files do not exist
-# RUN type 'C:\Program Files (x86)\Git\etc\install-options.txt'
-# RUN type ('{0}\AppData\Local\Programs\Git\etc\install-options.txt' -f $env:USERPROFILE)
-# RUN cat /etc/install-options.txt
-
-RUN mkdir C:\work
-WORKDIR C:\\work
+RUN powershell -Command $ErrorActionPreference = 'Stop' ; \
+    Invoke-WebRequest $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-busybox-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) -OutFile 'mingit.zip' -UseBasicParsing ; \
+    Expand-Archive mingit.zip -DestinationPath c:\mingit ; \
+    Remove-Item mingit.zip -Force ; \
+    setx /M PATH $('c:\mingit\cmd;{0}' -f $env:PATH)

--- a/git-for-windows-issue/README.md
+++ b/git-for-windows-issue/README.md
@@ -3,7 +3,8 @@
 This is a test setup to test Git for Windows in a Windows Docker container.
 See https://github.com/git-for-windows/git/issues/1007
 
-**Update**: It seems to be fixed with git-for-windows 2.13.0
+**Update**: It seems to be fixed with git-for-windows 2.13.0 -> not fully
+**Update 2**: It works with MinGit 2.15.1.2
 
 ## Build the Docker image
 
@@ -21,13 +22,13 @@ Test 1 works, inside the container file system
 .\run-test-1-in-container.ps1
 ```
 
-Test 2 does not work, directly in the mounted volume
+Test 2 works, directly in the mounted volume
 
 ```
 .\run-test-2-in-volume.ps1
 ```
 
-Test 3 does not work, directly in the mounted volume
+Test 3 works, directly in the mounted volume
 
 ```
 run-test-3-in-volume-currdir.ps1

--- a/git-for-windows-issue/run-test-2-in-volume.ps1
+++ b/git-for-windows-issue/run-test-2-in-volume.ps1
@@ -1,1 +1,1 @@
-docker run -v "$(pwd):C:\work" git-for-windows-issue git clone https://chromium.googlesource.com/external/gyp
+docker run -v "$(pwd):C:\work" -w C:/work git-for-windows-issue git clone https://chromium.googlesource.com/external/gyp

--- a/git-for-windows-issue/run-test-3-in-volume-currdir.ps1
+++ b/git-for-windows-issue/run-test-3-in-volume-currdir.ps1
@@ -1,1 +1,1 @@
-docker run -v "$(pwd):C:\work" git-for-windows-issue powershell -file .\test-currdir.ps1
+docker run -v "$(pwd):C:\work" -w C:/work git-for-windows-issue powershell -file ./test-currdir.ps1

--- a/git-for-windows-issue/run-test-4-in-volume-subdir.ps1
+++ b/git-for-windows-issue/run-test-4-in-volume-subdir.ps1
@@ -1,1 +1,1 @@
-docker run -v "$(pwd):C:\work" git-for-windows-issue powershell -file .\test-subdir.ps1
+docker run -v "$(pwd):C:\work" -w C:/work git-for-windows-issue powershell -file ./test-subdir.ps1


### PR DESCRIPTION
The MinGit BusyBox ZIP solves the problem to use `git clone` in a bind mounted volume.
