### PR TITLE
Update nodemon debug scenario for Insider 17074

### DIFF
--- a/node-example/.vscode/launch.json
+++ b/node-example/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Verwendet IntelliSense zum Ermitteln möglicher Node.js-Debugattribute.
+    // Zeigen Sie auf vorhandene Attribute, um die zugehörigen Beschreibungen anzuzeigen.
+    // Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Debug",
+            "address": "192.168.65.131",
+            "port": 9229,
+            "restart": true,
+            "remoteRoot": "c:\\code",
+            "localRoot": "${workspaceRoot}"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Start",
+            "program": "${workspaceRoot}/app.js"
+        }
+    ]
+}

--- a/node-example/Dockerfile
+++ b/node-example/Dockerfile
@@ -1,9 +1,9 @@
-FROM stefanscherer/node-windows:7.4.0-nano
+FROM stefanscherer/node-windows:9.4.0-insider-17074
 
 RUN npm install -g nodemon
 
 VOLUME C:/code
-RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\code' -Type String
-WORKDIR 'G:\\'
+#RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\code' -Type String
+#WORKDIR 'G:\\'
 
 CMD ["nodemon.cmd", "--debug=5858", "app.js"]

--- a/node-example/README.md
+++ b/node-example/README.md
@@ -1,61 +1,18 @@
 # node-example
 
 This is a test doing [Live Debugging With Docker](https://blog.docker.com/2016/07/live-debugging-docker/), but in Windows containers.
-There is an issue running `node` or `npm` in a volume mount point in the container.
+
+There was an issue running `node` or `npm` in a volume mount point in the container.
 See https://github.com/nodejs/node/issues/8897 for details.
+Beginning with Windows Insider Server Preview 17046 the volume mount points do not disturb Node.js anymore!
 
-```
-docker run -it -v c:\node-example:c:\code stefanscherer/node-windows:7.4.0-nano cmd
-```
-
-Now in the container
-
-```
-cd c:\code
-npm install
-```
-
-or
-
-```
-cd c:\code
-node test.js
-```
-
-One workaround is to use `C:\ContainerMappedDirectories` as the mount point in the container.
-
-Another workaround is to use a mapped drive. The volume `c:\code` will be mapped to drive letter `G:`
-and the working dir inside the container is `G:\`. Use the same option `-v c:\node-example:c:\code` to map your sources
-to the volume.
-
-```Dockerfile
-VOLUME C:/code
-RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\DOS Devices' -Name 'G:' -Value '\??\C:\code' -Type String
-WORKDIR 'G:\\'
-```
-
-Now you can work from your Windows Docker host with these commands.
-
-First we build the Docker image that installs nodemon to watch for file modifications.
-
-```
-docker-compose build
-```
-
-Now we install the Node.js dependencies of your app. As we do not have Node.js installed on our Docker host
-we run npm install inside a container.
-
-```
-docker run -v "$(pwd):c:\code" nodeexample_web npm.cmd install
-```
-
-You will see a new folder `node_modules` also on the Docker host.
-
-Now run the application with
+Now run the application with nodemon inspect in a Windows container
 
 ```
 docker-compose up
 ```
 
-You can change the the file `app.js` on your Windows Docker host and nodemon will restart
-the application after the change.
+You can change the the file `app.js` on your Windows Docker host and nodemon will restart the application after the change.
+
+Adjust the IP `"address"` in `.vscode/launch.json` to fit your Windows Docker machine (`docker-machine ip insider`).
+

--- a/node-example/app.js
+++ b/node-example/app.js
@@ -1,33 +1,33 @@
-var express = require('express');
-var expressHandlebars  = require('express-handlebars');
-var http = require('http');
+var express = require('express')
+var expressHandlebars = require('express-handlebars')
+var http = require('http')
 
-var PORT = 8000;
+var PORT = 8000
 
 var LINES = [
-    "Hey, now, you're an All Star, get your game on, go play",
-    "Hey, now, you're a Rock Star, get the show on, get paid",
-    "And all that glitters is gold",
-    "Only shooting stars break the mold",
-];
+  "Hey, now, you're an All Star, get your game on, go play",
+  "Hey, now, you're a Rock Star, get the show on, get paid",
+  'And all that glitters is gold',
+  'Only shooting stars break the mold'
+]
 
-var lineIndex = 0;
+var lineIndex = 0
 
-var app = express();
-app.engine('html', expressHandlebars());
-app.set('view engine', 'html');
-app.set('views', __dirname);
-app.get('/', function(req, res) {
-    var message = LINES[lineIndex];
+var app = express()
+app.engine('html', expressHandlebars())
+app.set('view engine', 'html')
+app.set('views', __dirname)
+app.get('/', function (req, res) {
+  var message = LINES[lineIndex]
 
-    lineIndex += 1;
-    if (lineIndex > LINES.length) {
-        lineIndex = 0;
-    }
+  lineIndex += 1
+  if (lineIndex > LINES.length) {
+    lineIndex = 0
+  }
+  console.log('message', message)
+  res.render('index', {message: message})
+})
 
-    res.render('index', {message: message});
-});
-
-http.Server(app).listen(PORT, function() {
-    console.log("HTTP server listening on port %s", PORT);
-});
+http.Server(app).listen(PORT, function () {
+  console.log('HTTP server listening on port %s', PORT)
+})

--- a/node-example/docker-compose.yml
+++ b/node-example/docker-compose.yml
@@ -1,14 +1,19 @@
-version: "2.1"
+version: "3.2"
 
 services:
   web:
     build: .
-    command: nodemon.cmd --debug=5858 app.js
+    command: nodemon.cmd --inspect=0.0.0.0:9229 app.js
+    working_dir: C:\code
     volumes:
-      - .:c:\code
+      # - .:c:\code
+      - type: bind
+        source: C:\Users\stefan\code\dockerfiles-windows\node-example
+        target: C:\code
+
     ports:
       - "8000:8000"
-      - "5858:5858"
+      - "9229:9229"
 
 networks:
   default:

--- a/node-example/package-lock.json
+++ b/node-example/package-lock.json
@@ -1,0 +1,2337 @@
+{
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "accepts": {
+            "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+            "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+            "requires": {
+                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+                "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+            }
+        },
+        "acorn": {
+            "version": "5.3.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/acorn/-/acorn-5.3.0.tgz",
+            "integrity": "sha1-dEbTlFnFT7SagObuZHgUm5QOyCI=",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "3.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+            "dev": true,
+            "requires": {
+                "acorn": "3.3.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                    "dev": true
+                }
+            }
+        },
+        "ajv": {
+            "version": "4.11.8",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/ajv/-/ajv-4.11.8.tgz",
+            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+            }
+        },
+        "ajv-keywords": {
+            "version": "1.5.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+            "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "requires": {
+                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+                "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+            }
+        },
+        "amdefine": {
+            "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+        },
+        "ansi-escapes": {
+            "version": "1.4.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
+        },
+        "array-flatten": {
+            "version": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+            }
+        },
+        "array-uniq": {
+            "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array.prototype.find": {
+            "version": "2.0.4",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+            "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+            "dev": true,
+            "requires": {
+                "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+                "es-abstract": "1.10.0"
+            }
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asap": {
+            "version": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+            "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
+        },
+        "async": {
+            "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            }
+        },
+        "balanced-match": {
+            "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        },
+        "brace-expansion": {
+            "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+            "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+            "requires": {
+                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            }
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "caller-path": {
+            "version": "0.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/caller-path/-/caller-path-0.1.0.tgz",
+            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+            "dev": true,
+            "requires": {
+                "callsites": "0.2.0"
+            }
+        },
+        "callsites": {
+            "version": "0.2.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/callsites/-/callsites-0.2.0.tgz",
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "optional": true
+        },
+        "center-align": {
+            "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "optional": true,
+            "requires": {
+                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+            }
+        },
+        "chalk": {
+            "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+        },
+        "circular-json": {
+            "version": "0.3.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/circular-json/-/circular-json-0.3.3.tgz",
+            "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+            "dev": true
+        },
+        "cli-cursor": {
+            "version": "1.0.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/cli-cursor/-/cli-cursor-1.0.2.tgz",
+            "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "1.0.1"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "optional": true,
+            "requires": {
+                "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "optional": true
+                }
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "concat-stream": {
+            "version": "1.6.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/concat-stream/-/concat-stream-1.6.0.tgz",
+            "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+            "dev": true,
+            "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "readable-stream": "2.3.3",
+                "typedarray": "0.0.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.3",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "contains-path": {
+            "version": "0.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/contains-path/-/contains-path-0.1.0.tgz",
+            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true
+        },
+        "content-disposition": {
+            "version": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+            "integrity": "sha1-h0dsamfI2qh+Muh2Ft+IO6f7Bxs="
+        },
+        "content-type": {
+            "version": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+            "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+        },
+        "cookie": {
+            "version": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "cookie-signature": {
+            "version": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        },
+        "core-util-is": {
+            "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "d": {
+            "version": "1.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/d/-/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "dev": true,
+            "requires": {
+                "es5-ext": "0.10.38"
+            }
+        },
+        "debug": {
+            "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+            "requires": {
+                "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+        },
+        "debug-log": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/debug-log/-/debug-log-1.0.1.tgz",
+            "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+            "dev": true
+        },
+        "decamelize": {
+            "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "optional": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+            "requires": {
+                "foreach": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+                "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+            }
+        },
+        "deglob": {
+            "version": "2.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/deglob/-/deglob-2.1.0.tgz",
+            "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
+            "dev": true,
+            "requires": {
+                "find-root": "1.1.0",
+                "glob": "7.1.2",
+                "ignore": "3.3.7",
+                "pkg-config": "1.1.1",
+                "run-parallel": "1.1.6",
+                "uniq": "1.0.1"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "minimatch": "3.0.4",
+                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                }
+            }
+        },
+        "del": {
+            "version": "2.2.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/del/-/del-2.2.2.tgz",
+            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "dev": true,
+            "requires": {
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.0",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "depd": {
+            "version": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+            "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+        },
+        "destroy": {
+            "version": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
+        "doctrine": {
+            "version": "2.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2"
+            }
+        },
+        "ee-first": {
+            "version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+        },
+        "encodeurl": {
+            "version": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+            "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+        },
+        "error-ex": {
+            "version": "1.3.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/error-ex/-/error-ex-1.3.1.tgz",
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.10.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/es-abstract/-/es-abstract-1.10.0.tgz",
+            "integrity": "sha1-Hss2wZeEKgDY7kwt/YZGu5fWCGQ=",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "1.1.1",
+                "function-bind": "1.1.1",
+                "has": "1.0.1",
+                "is-callable": "1.1.3",
+                "is-regex": "1.0.4"
+            },
+            "dependencies": {
+                "function-bind": {
+                    "version": "1.1.1",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/function-bind/-/function-bind-1.1.1.tgz",
+                    "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+                    "dev": true
+                }
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.1.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+            "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+            "dev": true,
+            "requires": {
+                "is-callable": "1.1.3",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.1"
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.38",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/es5-ext/-/es5-ext-0.10.38.tgz",
+            "integrity": "sha1-+n1A1lu8m7imfh0/nMZWoAUw7tM=",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-symbol": "3.1.1"
+            }
+        },
+        "es6-map": {
+            "version": "0.1.5",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/es6-map/-/es6-map-0.1.5.tgz",
+            "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-iterator": "2.0.3",
+                "es6-set": "0.1.5",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+            }
+        },
+        "es6-set": {
+            "version": "0.1.5",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/es6-set/-/es6-set-0.1.5.tgz",
+            "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/es6-symbol/-/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+            }
+        },
+        "escape-html": {
+            "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+        },
+        "escape-string-regexp": {
+            "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "escope": {
+            "version": "3.6.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/escope/-/escope-3.6.0.tgz",
+            "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+            "dev": true,
+            "requires": {
+                "es6-map": "0.1.5",
+                "es6-weak-map": "2.0.2",
+                "esrecurse": "4.2.0",
+                "estraverse": "4.2.0"
+            }
+        },
+        "eslint": {
+            "version": "3.19.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint/-/eslint-3.19.0.tgz",
+            "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.26.0",
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "concat-stream": "1.6.0",
+                "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                "doctrine": "2.1.0",
+                "escope": "3.6.0",
+                "espree": "3.5.2",
+                "esquery": "1.0.0",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "glob": "7.1.2",
+                "globals": "9.18.0",
+                "ignore": "3.3.7",
+                "imurmurhash": "0.1.4",
+                "inquirer": "0.12.0",
+                "is-my-json-valid": "2.17.1",
+                "is-resolvable": "1.0.1",
+                "js-yaml": "3.10.0",
+                "json-stable-stringify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.4",
+                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "1.2.1",
+                "progress": "1.1.8",
+                "require-uncached": "1.0.3",
+                "shelljs": "0.7.8",
+                "strip-bom": "3.0.0",
+                "strip-json-comments": "2.0.1",
+                "table": "3.8.3",
+                "text-table": "0.2.0",
+                "user-home": "2.0.0"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "minimatch": "3.0.4",
+                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.4",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/lodash/-/lodash-4.17.4.tgz",
+                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                },
+                "user-home": {
+                    "version": "2.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/user-home/-/user-home-2.0.0.tgz",
+                    "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+                    "dev": true,
+                    "requires": {
+                        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                    }
+                }
+            }
+        },
+        "eslint-config-standard": {
+            "version": "10.2.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
+            "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
+            "dev": true
+        },
+        "eslint-config-standard-jsx": {
+            "version": "4.0.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
+            "integrity": "sha1-AJ5TxN2x6e5wtGUP/mOn85+INuE=",
+            "dev": true
+        },
+        "eslint-import-resolver-node": {
+            "version": "0.2.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
+            "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
+            "dev": true,
+            "requires": {
+                "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                "object-assign": "4.1.1",
+                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-module-utils": {
+            "version": "2.1.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+            "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "pkg-dir": "1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-import": {
+            "version": "2.2.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
+            "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
+            "dev": true,
+            "requires": {
+                "builtin-modules": "1.1.1",
+                "contains-path": "0.1.0",
+                "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "0.2.3",
+                "eslint-module-utils": "2.1.1",
+                "has": "1.0.1",
+                "lodash.cond": "4.5.2",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "pkg-up": "1.0.0"
+            },
+            "dependencies": {
+                "doctrine": {
+                    "version": "1.5.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/doctrine/-/doctrine-1.5.0.tgz",
+                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "isarray": "1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-node": {
+            "version": "4.2.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
+            "integrity": "sha1-wEOQq428u2iHF0Aj1vOnJ2nmO5c=",
+            "dev": true,
+            "requires": {
+                "ignore": "3.3.7",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "object-assign": "4.1.1",
+                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+                "semver": "5.3.0"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-promise": {
+            "version": "3.5.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
+            "integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
+            "dev": true
+        },
+        "eslint-plugin-react": {
+            "version": "6.10.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
+            "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+            "dev": true,
+            "requires": {
+                "array.prototype.find": "2.0.4",
+                "doctrine": "1.5.0",
+                "has": "1.0.1",
+                "jsx-ast-utils": "1.4.1",
+                "object.assign": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz"
+            },
+            "dependencies": {
+                "doctrine": {
+                    "version": "1.5.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/doctrine/-/doctrine-1.5.0.tgz",
+                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "isarray": "1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-standard": {
+            "version": "3.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
+            "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+            "dev": true
+        },
+        "espree": {
+            "version": "3.5.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/espree/-/espree-3.5.2.tgz",
+            "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
+            "dev": true,
+            "requires": {
+                "acorn": "5.3.0",
+                "acorn-jsx": "3.0.1"
+            }
+        },
+        "esprima": {
+            "version": "4.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/esprima/-/esprima-4.0.0.tgz",
+            "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/esquery/-/esquery-1.0.0.tgz",
+            "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/esrecurse/-/esrecurse-4.2.0.tgz",
+            "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0",
+                "object-assign": "4.1.1"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "etag": {
+            "version": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+            "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+        },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38"
+            }
+        },
+        "exit-hook": {
+            "version": "1.1.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/exit-hook/-/exit-hook-1.1.1.tgz",
+            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+            "dev": true
+        },
+        "express": {
+            "version": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+            "integrity": "sha1-we4/Qs3Ikfs9xlCoki1R7IR9DWY=",
+            "requires": {
+                "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+                "array-flatten": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                "content-disposition": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+                "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+                "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+                "cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+                "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                "etag": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+                "finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+                "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+                "merge-descriptors": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+                "methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+                "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+                "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+                "proxy-addr": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz",
+                "qs": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+                "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+                "send": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+                "serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+                "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
+                "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                "vary": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+            }
+        },
+        "express-handlebars": {
+            "version": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-3.0.0.tgz",
+            "integrity": "sha1-gKBwu4GbCeSvLKbQeA91zgXnXC8=",
+            "requires": {
+                "glob": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+                "object.assign": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+                "promise": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
+            }
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "figures": {
+            "version": "1.7.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/figures/-/figures-1.7.0.tgz",
+            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                "object-assign": "4.1.1"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "file-entry-cache": {
+            "version": "2.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "dev": true,
+            "requires": {
+                "flat-cache": "1.3.0",
+                "object-assign": "4.1.1"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "finalhandler": {
+            "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+            "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
+            "requires": {
+                "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+                "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+            }
+        },
+        "find-root": {
+            "version": "1.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha1-q8/Iunb3CMQql7PWhbfpRQv7nOQ=",
+            "dev": true
+        },
+        "find-up": {
+            "version": "1.1.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/find-up/-/find-up-1.1.2.tgz",
+            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true,
+            "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "flat-cache": {
+            "version": "1.3.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/flat-cache/-/flat-cache-1.3.0.tgz",
+            "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+            "dev": true,
+            "requires": {
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "write": "0.2.1"
+            }
+        },
+        "foreach": {
+            "version": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+        },
+        "forwarded": {
+            "version": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+            "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+        },
+        "fresh": {
+            "version": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+            "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "function-bind": {
+            "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+            "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+        },
+        "generate-function": {
+            "version": "2.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/generate-function/-/generate-function-2.0.0.tgz",
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
+        },
+        "generate-object-property": {
+            "version": "1.2.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true,
+            "requires": {
+                "is-property": "1.0.2"
+            }
+        },
+        "get-stdin": {
+            "version": "5.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/get-stdin/-/get-stdin-5.0.1.tgz",
+            "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+            "dev": true
+        },
+        "glob": {
+            "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+            "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+            "requires": {
+                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            }
+        },
+        "globals": {
+            "version": "9.18.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/globals/-/globals-9.18.0.tgz",
+            "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+            "dev": true
+        },
+        "globby": {
+            "version": "5.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/globby/-/globby-5.0.0.tgz",
+            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+            "dev": true,
+            "requires": {
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "minimatch": "3.0.4",
+                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "graceful-fs": {
+            "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "handlebars": {
+            "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+            "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
+            "requires": {
+                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz"
+            }
+        },
+        "has": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/has/-/has-1.0.1.tgz",
+            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "dev": true,
+            "requires": {
+                "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            }
+        },
+        "has-ansi": {
+            "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            }
+        },
+        "http-errors": {
+            "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+            "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+            "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+                "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+            }
+        },
+        "ignore": {
+            "version": "3.3.7",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/ignore/-/ignore-3.3.7.tgz",
+            "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
+            "dev": true
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            }
+        },
+        "inherits": {
+            "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "inquirer": {
+            "version": "0.12.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/inquirer/-/inquirer-0.12.0.tgz",
+            "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "1.4.0",
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "cli-cursor": "1.0.2",
+                "cli-width": "2.2.0",
+                "figures": "1.7.0",
+                "lodash": "4.17.4",
+                "readline2": "1.0.1",
+                "run-async": "0.1.0",
+                "rx-lite": "3.1.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "through": "2.3.8"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.4",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/lodash/-/lodash-4.17.4.tgz",
+                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+                    "dev": true
+                }
+            }
+        },
+        "interpret": {
+            "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+            "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+            "dev": true
+        },
+        "ipaddr.js": {
+            "version": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+            "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+            "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
+        },
+        "is-callable": {
+            "version": "1.1.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-callable/-/is-callable-1.1.3.tgz",
+            "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+            "dev": true
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "1.0.1"
+            }
+        },
+        "is-my-json-valid": {
+            "version": "2.17.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+            "integrity": "sha1-PamJFKcKIvCoVj7xURokbG/FVHE=",
+            "dev": true,
+            "requires": {
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+        },
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "1.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+            "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+            "dev": true,
+            "requires": {
+                "is-path-inside": "1.0.1"
+            }
+        },
+        "is-path-inside": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "1.0.2"
+            }
+        },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
+        },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "1.0.1"
+            }
+        },
+        "is-resolvable": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-resolvable/-/is-resolvable-1.0.1.tgz",
+            "integrity": "sha1-rMoc022+RLl0uSQyFVWnC6A7HPQ=",
+            "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-symbol/-/is-symbol-1.0.1.tgz",
+            "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.10.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/js-yaml/-/js-yaml-3.10.0.tgz",
+            "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.9",
+                "esprima": "4.0.0"
+            }
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+            "integrity": "sha1-UBg80bLSUnXeBp6ecbRnrJ6rlzo=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "requires": {
+                "jsonify": "0.0.0"
+            }
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonpointer": {
+            "version": "4.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "jsx-ast-utils": {
+            "version": "1.4.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+            "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+            "dev": true
+        },
+        "kind-of": {
+            "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+            "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
+            "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+            }
+        },
+        "lazy-cache": {
+            "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "optional": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+            }
+        },
+        "load-json-file": {
+            "version": "4.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "parse-json": "4.0.0",
+                "pify": "3.0.0",
+                "strip-bom": "3.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                }
+            }
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+            },
+            "dependencies": {
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
+            }
+        },
+        "lodash.cond": {
+            "version": "4.5.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/lodash.cond/-/lodash.cond-4.5.2.tgz",
+            "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+            "dev": true
+        },
+        "longest": {
+            "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+        },
+        "media-typer": {
+            "version": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "merge-descriptors": {
+            "version": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+        },
+        "methods": {
+            "version": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+        },
+        "mime": {
+            "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+            "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+        },
+        "mime-db": {
+            "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
+            "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8="
+        },
+        "mime-types": {
+            "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+            "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
+            "requires": {
+                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+            }
+        },
+        "minimatch": {
+            "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+            "requires": {
+                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+            }
+        },
+        "minimist": {
+            "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+            "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        },
+        "mkdirp": {
+            "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
+            }
+        },
+        "ms": {
+            "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        },
+        "mute-stream": {
+            "version": "0.0.5",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/mute-stream/-/mute-stream-0.0.5.tgz",
+            "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "negotiator": {
+            "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "object-keys": {
+            "version": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+        },
+        "object.assign": {
+            "version": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+            "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+            "requires": {
+                "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+                "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+                "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+            }
+        },
+        "on-finished": {
+            "version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "requires": {
+                "ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+            }
+        },
+        "once": {
+            "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            }
+        },
+        "onetime": {
+            "version": "1.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/onetime/-/onetime-1.1.0.tgz",
+            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+            "dev": true
+        },
+        "optimist": {
+            "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "requires": {
+                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+            },
+            "dependencies": {
+                "wordwrap": {
+                    "version": "1.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/wordwrap/-/wordwrap-1.0.0.tgz",
+                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+                    "dev": true
+                }
+            }
+        },
+        "os-homedir": {
+            "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.2.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/p-limit/-/p-limit-1.2.0.tgz",
+            "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
+            "dev": true,
+            "requires": {
+                "p-try": "1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
+            "requires": {
+                "p-limit": "1.2.0"
+            }
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "dev": true,
+            "requires": {
+                "error-ex": "1.3.1",
+                "json-parse-better-errors": "1.0.1"
+            }
+        },
+        "parseurl": {
+            "version": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+            "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+        },
+        "path-exists": {
+            "version": "2.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/path-exists/-/path-exists-2.1.0.tgz",
+            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true,
+            "requires": {
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "path-to-regexp": {
+            "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "pkg-conf": {
+            "version": "2.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/pkg-conf/-/pkg-conf-2.1.0.tgz",
+            "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+            "dev": true,
+            "requires": {
+                "find-up": "2.1.0",
+                "load-json-file": "4.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                }
+            }
+        },
+        "pkg-config": {
+            "version": "1.1.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/pkg-config/-/pkg-config-1.1.1.tgz",
+            "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+            "dev": true,
+            "requires": {
+                "debug-log": "1.0.1",
+                "find-root": "1.1.0",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+        },
+        "pkg-dir": {
+            "version": "1.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/pkg-dir/-/pkg-dir-1.0.0.tgz",
+            "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+            "dev": true,
+            "requires": {
+                "find-up": "1.1.2"
+            }
+        },
+        "pkg-up": {
+            "version": "1.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/pkg-up/-/pkg-up-1.0.0.tgz",
+            "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+            "dev": true,
+            "requires": {
+                "find-up": "1.1.2"
+            }
+        },
+        "pluralize": {
+            "version": "1.2.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/pluralize/-/pluralize-1.2.1.tgz",
+            "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+            "dev": true
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "progress": {
+            "version": "1.1.8",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/progress/-/progress-1.1.8.tgz",
+            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+            "dev": true
+        },
+        "promise": {
+            "version": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+            "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
+            "requires": {
+                "asap": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+            }
+        },
+        "proxy-addr": {
+            "version": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz",
+            "integrity": "sha1-3JdQL1ci6IhGez+iKXp7H/R98HQ=",
+            "requires": {
+                "forwarded": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+                "ipaddr.js": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz"
+            }
+        },
+        "qs": {
+            "version": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+            "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs="
+        },
+        "range-parser": {
+            "version": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+        },
+        "readline2": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/readline2/-/readline2-1.0.1.tgz",
+            "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+            "dev": true,
+            "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "mute-stream": "0.0.5"
+            }
+        },
+        "rechoir": {
+            "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
+            "requires": {
+                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
+            }
+        },
+        "repeat-string": {
+            "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "dev": true,
+            "requires": {
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
+            }
+        },
+        "resolve": {
+            "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+            "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+            "dev": true,
+            "requires": {
+                "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+            }
+        },
+        "resolve-from": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/resolve-from/-/resolve-from-1.0.1.tgz",
+            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/restore-cursor/-/restore-cursor-1.0.1.tgz",
+            "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+            "dev": true,
+            "requires": {
+                "exit-hook": "1.1.1",
+                "onetime": "1.1.0"
+            }
+        },
+        "right-align": {
+            "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "optional": true,
+            "requires": {
+                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "minimatch": "3.0.4",
+                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                }
+            }
+        },
+        "run-async": {
+            "version": "0.1.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/run-async/-/run-async-0.1.0.tgz",
+            "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+            "dev": true,
+            "requires": {
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+            }
+        },
+        "run-parallel": {
+            "version": "1.1.6",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/run-parallel/-/run-parallel-1.1.6.tgz",
+            "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
+            "dev": true
+        },
+        "rx-lite": {
+            "version": "3.1.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/rx-lite/-/rx-lite-3.1.2.tgz",
+            "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+            "dev": true
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+            "dev": true
+        },
+        "send": {
+            "version": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+            "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
+            "requires": {
+                "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+                "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                "etag": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+                "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+                "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+                "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+                "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+            }
+        },
+        "serve-static": {
+            "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+            "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU=",
+            "requires": {
+                "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+                "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+                "send": "https://registry.npmjs.org/send/-/send-0.14.1.tgz"
+            }
+        },
+        "setprototypeof": {
+            "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+            "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
+        },
+        "shelljs": {
+            "version": "0.7.8",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/shelljs/-/shelljs-0.7.8.tgz",
+            "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+                "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                        "minimatch": "3.0.4",
+                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                }
+            }
+        },
+        "slice-ansi": {
+            "version": "0.0.4",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+            "dev": true
+        },
+        "source-map": {
+            "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+            "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+            "requires": {
+                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "standard": {
+            "version": "10.0.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/standard/-/standard-10.0.3.tgz",
+            "integrity": "sha1-eGm8v0Ir3uqraJof+x/qlnfdUOo=",
+            "dev": true,
+            "requires": {
+                "eslint": "3.19.0",
+                "eslint-config-standard": "10.2.1",
+                "eslint-config-standard-jsx": "4.0.2",
+                "eslint-plugin-import": "2.2.0",
+                "eslint-plugin-node": "4.2.3",
+                "eslint-plugin-promise": "3.5.0",
+                "eslint-plugin-react": "6.10.3",
+                "eslint-plugin-standard": "3.0.1",
+                "standard-engine": "7.0.0"
+            }
+        },
+        "standard-engine": {
+            "version": "7.0.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/standard-engine/-/standard-engine-7.0.0.tgz",
+            "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
+            "dev": true,
+            "requires": {
+                "deglob": "2.1.0",
+                "get-stdin": "5.0.1",
+                "minimist": "1.2.0",
+                "pkg-conf": "2.1.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "statuses": {
+            "version": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true,
+            "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            }
+        },
+        "strip-ansi": {
+            "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            }
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "table": {
+            "version": "3.8.3",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/table/-/table-3.8.3.tgz",
+            "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+            "dev": true,
+            "requires": {
+                "ajv": "4.11.8",
+                "ajv-keywords": "1.5.1",
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "lodash": "4.17.4",
+                "slice-ansi": "0.0.4",
+                "string-width": "2.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.4",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/lodash/-/lodash-4.17.4.tgz",
+                    "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2"
+            }
+        },
+        "type-is": {
+            "version": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
+            "integrity": "sha1-4hljnBfe0coHiQkt1UoDgmuBfLI=",
+            "requires": {
+                "media-typer": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
+            }
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+            "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
+            "optional": true,
+            "requires": {
+                "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                    "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                    "optional": true
+                },
+                "source-map": {
+                    "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                    "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                    "optional": true
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "optional": true
+        },
+        "uniq": {
+            "version": "1.0.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/uniq/-/uniq-1.0.1.tgz",
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+            "dev": true
+        },
+        "unpipe": {
+            "version": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+        },
+        "util-deprecate": {
+            "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "utils-merge": {
+            "version": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+            "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+        },
+        "vary": {
+            "version": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+            "integrity": "sha1-4eWv+70WrnaN0mdDlLmtMCJlMUA="
+        },
+        "window-size": {
+            "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "optional": true
+        },
+        "wordwrap": {
+            "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        },
+        "wrappy": {
+            "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "http://plossys.jfrog.io/plossys/api/npm/npm-repo/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+            }
+        },
+        "xtend": {
+            "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+            "optional": true,
+            "requires": {
+                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+            }
+        }
+    }
+}

--- a/node-example/package.json
+++ b/node-example/package.json
@@ -1,7 +1,13 @@
 {
     "main": "app.js",
+    "scripts": {
+        "test": "standard"
+    },
     "dependencies": {
         "express": "~4.14.0",
         "express-handlebars": "~3.0.0"
+    },
+    "devDependencies": {
+        "standard": "^10.0.3"
     }
 }

--- a/node-example/test.js
+++ b/node-example/test.js
@@ -1,2 +1,0 @@
-console.log('hello');
-// console.log('current directory: ' + process.cwd());

--- a/node/9.4/Dockerfile.insider
+++ b/node/9.4/Dockerfile.insider
@@ -39,7 +39,7 @@ ENV NPM_CONFIG_LOGLEVEL info
 
 COPY --from=download /nodejs /nodejs
 
-RUN $env:PATH = 'C:\nodejs;{0}' -f $env:PATH ; \ ; \
+RUN $env:PATH = 'C:\nodejs;{0}' -f $env:PATH ; \
     [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
 CMD [ "node.exe" ]


### PR DESCRIPTION
The latest Windows Insider Server Preview 17074 comes with a great new feature.
The mounted volumes are "real" folders inside the container and no longer a symlink to "ContainerMappedDirectories" share which disturbed Node.js finding files.

- [x] Node.js runs on mounted volumes
- [x] I can mount sources from my Mac into the Windows Docker Machine into a Windows Container running `nodemon --inspect`
- [x] nodemon restarts node.exe when I change code in VSCode on my Mac
- [x] I can attach with VSCode to the Windows node.exe process and debug my native Windows application on a Mac.

<img width="1440" alt="nodemon-vscode-debug-17074" src="https://user-images.githubusercontent.com/207759/35071713-00a93658-fbe2-11e7-92fd-74e50ec1de12.png">