### PR TITLE
Try procmon in a container

### DIFF
--- a/procmon/Dockerfile
+++ b/procmon/Dockerfile
@@ -1,0 +1,4 @@
+FROM microsoft/windowsservercore:10.0.14393.2007
+
+RUN reg add "HKCU\SOFTWARE\Sysinternals\Process Monitor" /v EulaAccepted /t REG_DWORD /d 1
+ADD https://live.sysinternals.com/procmon.exe procmon.exe

--- a/procmon/Dockerfile.insider
+++ b/procmon/Dockerfile.insider
@@ -1,0 +1,4 @@
+FROM microsoft/windowsservercore-insider
+
+RUN reg add "HKCU\SOFTWARE\Sysinternals\Process Monitor" /v EulaAccepted /t REG_DWORD /d 1
+ADD https://live.sysinternals.com/procmon.exe procmon.exe

--- a/procmon/README.md
+++ b/procmon/README.md
@@ -66,3 +66,8 @@ C:\>type abc.pml
 PML_	AABB08234517C:\Windows??????????
 ?B????
 ```
+
+## Forums
+
+* https://forum.sysinternals.com/procmon-in-windows-containers_topic32977.html
+* https://social.msdn.microsoft.com/Forums/vstudio/en-US/b20be612-95da-4476-8b15-052370b4321e/procmon-freezes-in-windowsservercore?forum=windowscontainers

--- a/procmon/README.md
+++ b/procmon/README.md
@@ -1,0 +1,68 @@
+# procmon in a container
+
+Try to run procmon - the Sysinternals Process Monitor - in a container.
+
+## Build the image
+
+```
+docker build -t procmon .
+```
+
+## Capturing
+
+With `procmon /quiet /minimized /backingfile abc.pml` you can start capturing.
+
+With `procmon /terminate` you can stop capturing.
+
+## Issues
+
+The captured file doesn't look good. It starts with 4,194,304 byte, after
+terminating the capture the file is only 976 byte. This happens in 17093 insider builds.
+In a 10.14393.2007 windowsservercore image the file is 4,194,304 byte, but also doesn't look good.
+
+```
+$ docker run -it procmon cmd
+
+Microsoft Windows [Version 10.0.17093.1000]
+(c) 2017 Microsoft Corporation. All rights reserved.
+
+C:\>procmon /quiet /minimized /backingfile abc.pml
+
+C:\>dir
+ Volume in drive C has no label.
+ Volume Serial Number is 6C54-E4C6
+
+ Directory of C:\
+
+02/14/2018  12:11 PM         4,194,304 abc.pml
+02/03/2018  03:10 AM             1,894 License.txt
+02/13/2018  01:23 PM         2,164,360 procmon.exe
+02/03/2018  03:13 AM    <DIR>          Program Files
+02/14/2018  12:11 PM    <DIR>          Program Files (x86)
+02/03/2018  03:14 AM    <DIR>          Users
+02/14/2018  12:10 PM    <DIR>          Windows
+               3 File(s)      6,360,558 bytes
+               4 Dir(s)  21,290,831,872 bytes free
+
+C:\>procmon /terminate
+
+C:\>dir
+ Volume in drive C has no label.
+ Volume Serial Number is 6C54-E4C6
+
+ Directory of C:\
+
+02/14/2018  12:11 PM               976 abc.pml
+02/03/2018  03:10 AM             1,894 License.txt
+02/13/2018  01:23 PM         2,164,360 procmon.exe
+02/03/2018  03:13 AM    <DIR>          Program Files
+02/14/2018  12:11 PM    <DIR>          Program Files (x86)
+02/03/2018  03:14 AM    <DIR>          Users
+02/14/2018  12:10 PM    <DIR>          Windows
+               3 File(s)      2,167,230 bytes
+               4 Dir(s)  21,296,209,920 bytes free
+
+C:\>type abc.pml
+PML_	AABB08234517C:\Windows??????????
+?B????
+```


### PR DESCRIPTION
# procmon in a container

Try to run procmon - the Sysinternals Process Monitor - in a container.

## Build the image

```
docker build -t procmon .
```

## Capturing

With `procmon /quiet /minimized /backingfile abc.pml` you can start capturing.

With `procmon /terminate` you can stop capturing.

## Issues

The captured file doesn't look good. It starts with 4,194,304 byte, after
terminating the capture the file is only 976 byte. This happens in 17093 insider builds.
In a 10.14393.2007 windowsservercore image the file is 4,194,304 byte, but also doesn't look good.

/cc @konstantinpae FYI
