### PR TITLE
Add netapi-helper image for some golang binaries

### DIFF
--- a/golang-netapi-helper/Dockerfile
+++ b/golang-netapi-helper/Dockerfile
@@ -1,0 +1,4 @@
+FROM microsoft/windowsservercore:1709 AS core
+FROM microsoft/nanoserver:1709
+# workaround until https://github.com/golang/go/issues/21867 is fixed
+COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll

--- a/golang-netapi-helper/README.md
+++ b/golang-netapi-helper/README.md
@@ -1,0 +1,9 @@
+# golang netapi32.dll helper image
+
+If you want to run a Golang binary in a NanoServer container 1709 or newer you might run into trouble
+with a missing `netapi32.dll` DLL.
+
+The work in progress to fix this in a future version of Golang can be found at https://github.com/golang/go/issues/21867
+
+As a workaround use this image which has a copy of the DLL from the Server Core base image.
+

--- a/golang-netapi-helper/build.sh
+++ b/golang-netapi-helper/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t stefanscherer/netapi-helper:1709 .

--- a/golang-netapi-helper/push.sh
+++ b/golang-netapi-helper/push.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker push stefanscherer/netapi-helper:1709


### PR DESCRIPTION
If you want to run a Golang binary in a NanoServer container 1709 or newer you might run into trouble with a missing `netapi32.dll` DLL.

The work in progress to fix this in a future version of Golang can be found at https://github.com/golang/go/issues/21867

As a workaround use this image which has a copy of the DLL from the Server Core base image.