### PR TITLE
Build swarm 1709 image with netapi32.dll

### DIFF
--- a/swarm/build.ps1
+++ b/swarm/build.ps1
@@ -1,2 +1,3 @@
+$version=$(select-string -Path Dockerfile -Pattern "ENV SWARM_VERSION").ToString().split()[-1]
 docker build -t swarm .
-docker tag swarm:latest swarm:1.2.8
+docker tag swarm:latest swarm:$version

--- a/swarm/push.ps1
+++ b/swarm/push.ps1
@@ -1,5 +1,25 @@
-docker tag swarm:1.2.8 stefanscherer/swarm-windows:1.2.8
-docker tag swarm:latest stefanscherer/swarm-windows:latest
+$version=$(select-string -Path Dockerfile -Pattern "ENV SWARM_VERSION").ToString().split()[-1]
 
-docker push stefanscherer/swarm-windows:1.2.8
-docker push stefanscherer/swarm-windows:latest
+docker tag swarm:$version stefanscherer/swarm-windows:$version-1607
+docker push stefanscherer/swarm-windows:$version-1607
+
+npm install -g rebase-docker-image
+
+rebase-docker-image stefanscherer/swarm-windows:$version-1607 `
+  -s microsoft/nanoserver:10.0.14393.2068 `
+  -t stefanscherer/swarm-windows:$version-1709 `
+  -b stefanscherer/netapi-helper:1709
+
+..\update-docker-cli.ps1
+
+docker manifest create `
+  stefanscherer/swarm-windows:$version `
+  stefanscherer/swarm-windows:$version-1607 `
+  stefanscherer/swarm-windows:$version-1709
+docker manifest push stefanscherer/swarm-windows:$version
+
+docker manifest create `
+  stefanscherer/swarm-windows:latest `
+  stefanscherer/swarm-windows:$version-1607 `
+  stefanscherer/swarm-windows:$version-1709
+docker manifest push stefanscherer/swarm-windows:latest

--- a/swarm/test.ps1
+++ b/swarm/test.ps1
@@ -1,2 +1,3 @@
-docker run swarm:1.2.8 --help
-docker run swarm:1.2.8 create
+$version=$(select-string -Path Dockerfile -Pattern "ENV SWARM_VERSION").ToString().split()[-1]
+docker run swarm:$version --help
+docker run swarm:$version create


### PR DESCRIPTION
Use rebase-docker-image 0.3.0 to rebase the 2016 swarm image to 1709 including the missing netapi32.dll from a helper image.
Build manifest list for 2016 + 1709.
Improvement for #269 to build everything on AppVeyor.
Workaround for https://github.com/golang/go/issues/21867
