### PR TITLE
Build Traefik 1709 image with netapi32.dll

### DIFF
--- a/traefik/push.ps1
+++ b/traefik/push.ps1
@@ -1,5 +1,25 @@
 $version=$(select-string -Path Dockerfile -Pattern "ENV TRAEFIK_VERSION").ToString().split()[-1]
-docker tag traefik stefanscherer/traefik-windows
-docker tag traefik stefanscherer/traefik-windows:v$version
-docker push stefanscherer/traefik-windows:v$version
-docker push stefanscherer/traefik-windows
+
+docker tag traefik stefanscherer/traefik-windows:v$version-1607
+docker push stefanscherer/traefik-windows:v$version-1607
+
+npm install -g rebase-docker-image
+
+rebase-docker-image stefanscherer/traefik-windows:v$version-1607 `
+  -s microsoft/nanoserver:10.0.14393.2068 `
+  -t stefanscherer/traefik-windows:v$version-1709 `
+  -b stefanscherer/netapi-helper:1709
+
+..\update-docker-cli.ps1
+
+docker manifest create `
+  stefanscherer/traefik-windows:v$version `
+  stefanscherer/traefik-windows:v$version-1607 `
+  stefanscherer/traefik-windows:v$version-1709
+docker manifest push stefanscherer/traefik-windows:v$version
+
+docker manifest create `
+  stefanscherer/traefik-windows:latest `
+  stefanscherer/traefik-windows:v$version-1607 `
+  stefanscherer/traefik-windows:v$version-1709
+docker manifest push stefanscherer/traefik-windows:latest


### PR DESCRIPTION
Use rebase-docker-image 0.3.0 to rebase the 2016 traefik image to 1709 including the missing netapi32.dll from a helper image.
Build manifest list for 2016 + 1709.
Workaround for https://github.com/golang/go/issues/21867