### PR TITLE
Copy correct swarm binary to final stage

### DIFF
--- a/swarm/Dockerfile
+++ b/swarm/Dockerfile
@@ -1,7 +1,21 @@
-FROM golang:windowsservercore AS build
+# escape=`
+FROM golang:nanoserver AS build
 
 ENV SWARM_VERSION v1.2.8
 
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GIT_VERSION 2.14.2
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/v${GIT_VERSION}.windows.1/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_SHA256 9638733b8d749c43d59c34a714d582b2352356ee7d13c4acf919c18f307387f5
+
+RUN Invoke-WebRequest -UseBasicParsing $env:GIT_DOWNLOAD_URL -OutFile git.zip; `
+    if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_SHA256) {exit 1} ; `
+    Expand-Archive git.zip -DestinationPath C:\git; `
+    Remove-Item git.zip; `
+    Write-Host 'Updating PATH ...'; `
+    $env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; `
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH
 RUN mkdir src\github.com\docker
 WORKDIR /go/src/github.com/docker
 RUN git clone https://github.com/docker/swarm
@@ -11,7 +25,7 @@ RUN go install .
 
 FROM microsoft/nanoserver:10.0.14393.2068
 
-COPY --from=build /go/src/github.com/docker/swarm/swarm.exe /swarm.exe
+COPY --from=build /go/bin/swarm.exe /swarm.exe
 
 ENV SWARM_HOST :2375
 EXPOSE 2375

--- a/swarm/Dockerfile.1709
+++ b/swarm/Dockerfile.1709
@@ -11,7 +11,7 @@ RUN go install .
 
 FROM microsoft/nanoserver:1709
 
-COPY --from=build /go/src/github.com/docker/swarm/swarm.exe /swarm.exe
+COPY --from=build /go/bin/swarm.exe /swarm.exe
 
 # nanoserver 1709 is missing the netapi32.dll
 COPY --from=build /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll

--- a/swarm/build.ps1
+++ b/swarm/build.ps1
@@ -1,3 +1,3 @@
-$version=$(select-string -Path Dockerfile -Pattern "ENV SWARM_VERSION").ToString().split()[-1]
+$version=$(select-string -Path Dockerfile -Pattern "ENV SWARM_VERSION").ToString().split()[-1].SubString(1)
 docker build -t swarm .
 docker tag swarm:latest swarm:$version

--- a/swarm/push.ps1
+++ b/swarm/push.ps1
@@ -1,4 +1,4 @@
-$version=$(select-string -Path Dockerfile -Pattern "ENV SWARM_VERSION").ToString().split()[-1]
+$version=$(select-string -Path Dockerfile -Pattern "ENV SWARM_VERSION").ToString().split()[-1].SubString(1)
 
 docker tag swarm:$version stefanscherer/swarm-windows:$version-1607
 docker push stefanscherer/swarm-windows:$version-1607

--- a/swarm/test.ps1
+++ b/swarm/test.ps1
@@ -4,4 +4,3 @@ $isVersion=$(docker run swarm:$version --version).split()[-2]
 if (!($version -eq $isVersion)) {
   Write-Error "Got wrong version $isVersion, expected $version"
 }
-docker run swarm:$version create

--- a/swarm/test.ps1
+++ b/swarm/test.ps1
@@ -1,3 +1,7 @@
-$version=$(select-string -Path Dockerfile -Pattern "ENV SWARM_VERSION").ToString().split()[-1]
+$version=$(select-string -Path Dockerfile -Pattern "ENV SWARM_VERSION").ToString().split()[-1].SubString(1)
 docker run swarm:$version --help
+$isVersion=$(docker run swarm:$version --version).split()[-2]
+if (!($version -eq $isVersion)) {
+  Write-Error "Got wrong version $isVersion, expected $version"
+}
 docker run swarm:$version create


### PR DESCRIPTION
The line

```Dockerfile
COPY --from=build /go/src/github.com/docker/swarm/swarm.exe /swarm.exe
```

was wrong as it copied the old `swarm.exe` from the GitHub repo. The compiled `swarm.exe` 1.2.8 can be found at `/go/bin/swarm.exe`. Ping @gamma ;-)

Added a test to check the correct version of swarm.exe

Fixed Docker tag, removed `v`

Build the multi-os image on AppVeyor.
