### PR TITLE
Small LCOW example with docker-compose

### DIFF
--- a/compose/lcow/README.md
+++ b/compose/lcow/README.md
@@ -1,0 +1,32 @@
+# Compose Linux + Windows containers
+
+In LCOW mode it is possible to use `docker-compose` to mix Linux and Windows containers.
+
+## Example
+
+I had to cheat a little bit.
+
+Pre-pull the Linux image with the `--platform` option.
+
+```
+docker pull --platform linux tutum/curl:alpine
+```
+
+```
+docker-compose up
+```
+
+The hosts table does not have the `win` machine.
+
+In a different terminal run
+
+```
+docker inspect lcow_win_1
+```
+
+Fetch the IPAddress of the Window container. Now enter the Linux container and append the `win` container to the hosts table.
+
+```
+docker-compose exec lin sh
+echo "1.2.3.4 win" >> /etc/hosts
+```

--- a/compose/lcow/docker-compose.yml
+++ b/compose/lcow/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2.1'
+services:
+  lin:
+    image: tutum/curl:alpine
+    command: watch curl http://win:8080
+    links:
+      - win
+
+  win:
+    image: stefanscherer/whoami
+
+


### PR DESCRIPTION
# Compose Linux + Windows containers

In LCOW mode it is possible to use `docker-compose` to mix Linux and Windows containers.

## Example

I had to cheat a little bit.

Pre-pull the Linux image with the `--platform` option.

```
docker pull --platform linux tutum/curl:alpine
```

```
docker-compose up
```

The hosts table does not have the `win` machine.

In a different terminal run

```
docker inspect lcow_win_1
```

Fetch the IPAddress of the Window container. Now enter the Linux container and append the `win` container to the hosts table.

```
docker-compose exec lin sh
echo "1.2.3.4 win" >> /etc/hosts
```