### PR TITLE
Fix docker-cli 1709 image

### DIFF
--- a/docker-cli/Dockerfile
+++ b/docker-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:10.0.14393.2125 as download
+FROM microsoft/windowsservercore:10.0.14393.2189 as download
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -12,6 +12,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Invoke-WebRequest $('https://github.com/docker/toolbox/releases/download/v{0}/DockerToolbox-{0}.exe' -f $env:DOCKER_VERSION) -OutFile 'dockertoolbox.exe' -UseBasicParsing
 RUN /innoextract.exe dockertoolbox.exe
 
-FROM microsoft/nanoserver:10.0.14393.2125
+FROM microsoft/nanoserver:10.0.14393.2189
 COPY --from=download /app/docker.exe /
 CMD [ "docker.exe" ]

--- a/docker-cli/push.ps1
+++ b/docker-cli/push.ps1
@@ -6,7 +6,7 @@ npm install -g rebase-docker-image
 rebase-docker-image `
   stefanscherer/docker-cli-windows:$version-1607 `
   -t stefanscherer/docker-cli-windows:$version-1709 `
-  -b microsoft/nanoserver:1709_KB4074588
+  -b stefanscherer/netapi-helper:1709
 
 ..\update-docker-cli.ps1
 

--- a/docker-cli/push.ps1
+++ b/docker-cli/push.ps1
@@ -5,6 +5,7 @@ docker push stefanscherer/docker-cli-windows:$version-1607
 npm install -g rebase-docker-image
 rebase-docker-image `
   stefanscherer/docker-cli-windows:$version-1607 `
+  -s microsoft/nanoserver:10.0.14393.2189 `
   -t stefanscherer/docker-cli-windows:$version-1709 `
   -b stefanscherer/netapi-helper:1709
 


### PR DESCRIPTION
The docker.exe also uses glog and crashes in microsoft/nanoserver:1709 container.
Use the netapi-helper base image for the rebase step.
