### PR TITLE
Build Node.js image for 1803

### DIFF
--- a/node/10.0/Dockerfile
+++ b/node/10.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:10.0.14393.2189 as download
+FROM microsoft/windowsservercore as download
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -44,7 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
       ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
     Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
 
-FROM microsoft/windowsservercore:10.0.14393.2189
+FROM microsoft/windowsservercore:10.0.14393.2248
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/node/10.0/nano/Dockerfile
+++ b/node/10.0/nano/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:10.0.14393.2189 as download
+FROM microsoft/windowsservercore as download
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -44,7 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
       ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
     Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
 
-FROM microsoft/nanoserver:10.0.14393.2189
+FROM microsoft/nanoserver:10.0.14393.2248
 
 ENV NPM_CONFIG_LOGLEVEL info
 

--- a/node/8.11/Dockerfile
+++ b/node/8.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:10.0.14393.2068 as download
+FROM microsoft/windowsservercore as download
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -44,7 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
       ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
     Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
 
-FROM microsoft/windowsservercore:10.0.14393.2068
+FROM microsoft/windowsservercore:10.0.14393.2248
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/node/8.11/nano/Dockerfile
+++ b/node/8.11/nano/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:10.0.14393.2068 as download
+FROM microsoft/windowsservercore as download
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -44,7 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
       ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
     Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
 
-FROM microsoft/nanoserver:10.0.14393.2068
+FROM microsoft/nanoserver:10.0.14393.2248
 
 ENV NPM_CONFIG_LOGLEVEL info
 

--- a/node/push.ps1
+++ b/node/push.ps1
@@ -15,6 +15,7 @@ function pushVersion($majorMinorPatch, $majorMinor, $major) {
   }
 
   rebase-docker-image stefanscherer/node-windows:$majorMinorPatch-nanoserver-2016 -t stefanscherer/node-windows:$majorMinorPatch-nanoserver-1709 -b microsoft/nanoserver:1709
+  rebase-docker-image stefanscherer/node-windows:$majorMinorPatch-nanoserver-2016 -t stefanscherer/node-windows:$majorMinorPatch-nanoserver-1803 -b microsoft/nanoserver:1803
 
   $coreManifest = @"
 image: stefanscherer/node-windows:{0}-windowsservercore
@@ -42,6 +43,11 @@ manifests:
       os: windows
   -
     image: stefanscherer/node-windows:{0}-nanoserver-1709
+    platform:
+      architecture: amd64
+      os: windows
+  -
+    image: stefanscherer/node-windows:{0}-nanoserver-1803
     platform:
       architecture: amd64
       os: windows


### PR DESCRIPTION
Build manifest list for Node.js 10.0.0 image for Windows Server 2016, version 1709 and version 1803.
