### PR TITLE
Build Docker CLI image for 1803

### DIFF
--- a/docker-cli/Dockerfile
+++ b/docker-cli/Dockerfile
@@ -12,6 +12,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Invoke-WebRequest $('https://github.com/docker/toolbox/releases/download/v{0}/DockerToolbox-{0}.exe' -f $env:DOCKER_VERSION) -OutFile 'dockertoolbox.exe' -UseBasicParsing
 RUN /innoextract.exe dockertoolbox.exe
 
-FROM microsoft/nanoserver:ltsc2016
+FROM microsoft/nanoserver:sac2016
 COPY --from=download /app/docker.exe /
 CMD [ "docker.exe" ]

--- a/docker-cli/Dockerfile
+++ b/docker-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:10.0.14393.2189 as download
+FROM microsoft/windowsservercore as download
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -12,6 +12,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Invoke-WebRequest $('https://github.com/docker/toolbox/releases/download/v{0}/DockerToolbox-{0}.exe' -f $env:DOCKER_VERSION) -OutFile 'dockertoolbox.exe' -UseBasicParsing
 RUN /innoextract.exe dockertoolbox.exe
 
-FROM microsoft/nanoserver:10.0.14393.2189
+FROM microsoft/nanoserver:ltsc2016
 COPY --from=download /app/docker.exe /
 CMD [ "docker.exe" ]

--- a/docker-cli/push.ps1
+++ b/docker-cli/push.ps1
@@ -5,20 +5,27 @@ docker push stefanscherer/docker-cli-windows:$version-1607
 npm install -g rebase-docker-image
 rebase-docker-image `
   stefanscherer/docker-cli-windows:$version-1607 `
-  -s microsoft/nanoserver:10.0.14393.2189 `
+  -s microsoft/nanoserver:sac2016 `
   -t stefanscherer/docker-cli-windows:$version-1709 `
   -b stefanscherer/netapi-helper:1709
+rebase-docker-image `
+  stefanscherer/docker-cli-windows:$version-1607 `
+  -s microsoft/nanoserver:sac2016 `
+  -t stefanscherer/docker-cli-windows:$version-1803 `
+  -b stefanscherer/netapi-helper:1803
 
 ..\update-docker-cli.ps1
 
 docker manifest create `
   stefanscherer/docker-cli-windows:$version `
   stefanscherer/docker-cli-windows:$version-1607 `
-  stefanscherer/docker-cli-windows:$version-1709
+  stefanscherer/docker-cli-windows:$version-1709 `
+  stefanscherer/docker-cli-windows:$version-1803
 docker manifest push stefanscherer/docker-cli-windows:$version
 
 docker manifest create `
   stefanscherer/docker-cli-windows:latest `
   stefanscherer/docker-cli-windows:$version-1607 `
-  stefanscherer/docker-cli-windows:$version-1709
+  stefanscherer/docker-cli-windows:$version-1709 `
+  stefanscherer/docker-cli-windows:$version-1803
 docker manifest push stefanscherer/docker-cli-windows:latest


### PR DESCRIPTION
Build multi-os image with Docker CLI for 2016, 1709 and 1803.