### PR TITLE
Build webserver with 17744 insider

### DIFF
--- a/webserver/.dockerignore
+++ b/webserver/.dockerignore
@@ -1,0 +1,4 @@
+webserver.exe
+*.ps1
+*.md
+Dockerfile*

--- a/webserver/Dockerfile.insider
+++ b/webserver/Dockerfile.insider
@@ -1,0 +1,16 @@
+FROM stefanscherer/golang-windows:1.11-10.0.17744.1001 as gobuild
+
+COPY . /code
+WORKDIR /code
+
+USER ContainerAdministrator
+
+RUN go build webserver.go
+
+FROM mcr.microsoft.com/nanoserver-insider:10.0.17744.1001
+
+COPY --from=gobuild /code/webserver.exe /webserver.exe
+
+EXPOSE 8080
+
+CMD ["\\webserver.exe"]

--- a/webserver/Dockerfile.insider
+++ b/webserver/Dockerfile.insider
@@ -3,8 +3,6 @@ FROM stefanscherer/golang-windows:1.11-10.0.17744.1001 as gobuild
 COPY . /code
 WORKDIR /code
 
-USER ContainerAdministrator
-
 RUN go build webserver.go
 
 FROM mcr.microsoft.com/nanoserver-insider:10.0.17744.1001


### PR DESCRIPTION
The default user ContainerUser is weird, golang cannot write webserver.exe into /code folder

```
$ docker build -t stefanscherer/webserver-windows:0.2.1-10.0.17744.1001 -f Dockerfile.insider .
Sending build context to Docker daemon   6.07MB
Step 1/8 : FROM stefanscherer/golang-windows:1.11-10.0.17744.1001 as gobuild
 ---> cdccbbfc5976
Step 2/8 : COPY . /code
 ---> Using cache
 ---> 9a47ba44eddc
Step 3/8 : WORKDIR /code
 ---> Using cache
 ---> 8a385309a03b
Step 4/8 : RUN go build webserver.go
 ---> Running in b28c91bd7fa1
go build command-line-arguments: open webserver.exe: Access is denied.
The command 'cmd /S /C go build webserver.go' returned a non-zero code: 1
```

I have to add `USER ContainerAdministrator` again to make it work:

```
$ docker build -t stefanscherer/webserver-windows:0.2.1-10.0.17744.1001 -f Dockerfile.insider .
Sending build context to Docker daemon   6.07MB
Step 1/9 : FROM stefanscherer/golang-windows:1.11-10.0.17744.1001 as gobuild
 ---> cdccbbfc5976
Step 2/9 : COPY . /code
 ---> c66282a84e7a
Step 3/9 : WORKDIR /code
Removing intermediate container ff47d2b66384
 ---> 5d39df56ace3
Step 4/9 : USER ContainerAdministrator
 ---> Running in 8a420597be7e
Removing intermediate container 8a420597be7e
 ---> 4b8f56ff7a78
Step 5/9 : RUN go build webserver.go
 ---> Running in 50be28c6f6c9
Removing intermediate container 50be28c6f6c9
 ---> 507c44375a16
Step 6/9 : FROM mcr.microsoft.com/nanoserver-insider:10.0.17744.1001
 ---> a0128f6324b4
Step 7/9 : COPY --from=gobuild /code/webserver.exe /webserver.exe
 ---> 9e55d5ce3739
Step 8/9 : EXPOSE 8080
 ---> Running in 1f91c267e14d
Removing intermediate container 1f91c267e14d
 ---> a86f3be80884
Step 9/9 : CMD ["\\webserver.exe"]
 ---> Running in c5324579f414
Removing intermediate container c5324579f414
 ---> 399ec7b260f0
Successfully built 399ec7b260f0
Successfully tagged stefanscherer/webserver-windows:0.2.1-10.0.17744.1001
```
