### PR TITLE
Update Node.js 10.12.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ version: 1.0.{build}
 image: Visual Studio 2017
 
 # Uncomment to debug via RDP
-# init:
-#   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+init:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 # 
-# on_finish:
-#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 environment:
   APPVEYOR_RDP_PASSWORD:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ version: 1.0.{build}
 image: Visual Studio 2017
 
 # Uncomment to debug via RDP
-init:
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# init:
+#   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 # 
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 environment:
   APPVEYOR_RDP_PASSWORD:

--- a/node/10/Dockerfile
+++ b/node/10/Dockerfile
@@ -23,7 +23,7 @@ RUN @( \
       gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
     }
 
-ENV NODE_VERSION 10.11.0
+ENV NODE_VERSION 10.12.0
 
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
     gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
@@ -34,7 +34,7 @@ RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f 
     Expand-Archive node.zip -DestinationPath C:\ ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
     Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
@@ -47,9 +47,9 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
       ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
     Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
 
-ENV GIT_VERSION 2.18.0
+ENV GIT_VERSION 2.19.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/v${GIT_VERSION}.windows.1/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_SHA256 1dfd05de1320d57f448ed08a07c0b9de2de8976c83840f553440689b5db6a1cf
+ENV GIT_SHA256 f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
     Invoke-WebRequest -UseBasicParsing $env:GIT_DOWNLOAD_URL -OutFile git.zip; \

--- a/node/10/README.md
+++ b/node/10/README.md
@@ -1,22 +1,22 @@
 # Node
 
-A Windows Server Core Docker container image with Node.js 10.11.0 installed.
+A Windows Server Core Docker container image with Node.js 10.12.0 installed.
 
 ## Images
 
-- stefanscherer/node-windows:10.11.0 -> Nano Server + Node + NPM + Yarn + Git
-- stefanscherer/node-windows:10.11.0-pure -> Nano Server + Node
-- stefanscherer/node-windows:10.11.0-windowsservercore -> Windows Server Core + Node + NPM + Yarn + Git
-- stefanscherer/node-windows:10.11.0-build-tools -> + Python + C++ build tools
+- stefanscherer/node-windows:10.12.0 -> Nano Server + Node + NPM + Yarn + Git
+- stefanscherer/node-windows:10.12.0-pure -> Nano Server + Node
+- stefanscherer/node-windows:10.12.0-windowsservercore -> Windows Server Core + Node + NPM + Yarn + Git
+- stefanscherer/node-windows:10.12.0-build-tools -> + Python + C++ build tools
 
 ## Building
 
 To build the images yourself use the following commands:
 
 ```
-docker build -t node:10.11.0-windowsservercore .
-docker build -t node:10.11.0-nanoserver nano
-docker build -t node:10.11.0-pure pure
+docker build -t node:10.12.0-windowsservercore .
+docker build -t node:10.12.0-nanoserver nano
+docker build -t node:10.12.0-pure pure
 ```
 
 ### Build with 1709 or newer base images
@@ -26,14 +26,14 @@ On Windows Server 1709 or 1803 or any current Windows 10 machine you might want 
 The `Dockerfile` is prepared to run on any Windows platform, but you have to specify some build arguments to make it work with newer base images.
 
 ```
-docker build -t node:10.11.0-windowsservercore `
+docker build -t node:10.12.0-windowsservercore `
   --build-arg core=microsoft/windowsservercore:1803 `
   --build-arg target=microsoft/nanoserver:1803 .
-docker build -t node:10.11.0-nanoserver `
+docker build -t node:10.12.0-nanoserver `
   --build-arg core=microsoft/windowsservercore:1803 `
   --build-arg target=microsoft/nanoserver:1803 `
   --build-arg "SETX= " nano
-docker build -t node:10.11.0-pure `
+docker build -t node:10.12.0-pure `
   --build-arg core=microsoft/windowsservercore:1803 `
   --build-arg target=microsoft/nanoserver:1803 pure
 ```

--- a/node/10/build-tools/Dockerfile
+++ b/node/10/build-tools/Dockerfile
@@ -1,4 +1,4 @@
-ARG node=node:10.11.0-windowsservercore
+ARG node=node:10.12.0-windowsservercore
 FROM $node
 
 RUN npm install --global --production --add-python-to-path windows-build-tools --vs2015

--- a/node/10/build-tools/Dockerfile.insider
+++ b/node/10/build-tools/Dockerfile.insider
@@ -1,3 +1,3 @@
-FROM stefanscherer/node-windows:10.11.0-insider-core
+FROM stefanscherer/node-windows:10.12.0-insider-core
 
 RUN npm install --global --production --add-python-to-path windows-build-tools --vs2015

--- a/node/10/nano/Dockerfile
+++ b/node/10/nano/Dockerfile
@@ -23,7 +23,7 @@ RUN @( \
       gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
     }
 
-ENV NODE_VERSION 10.11.0
+ENV NODE_VERSION 10.12.0
 
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
     gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
@@ -34,7 +34,7 @@ RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f 
     Expand-Archive node.zip -DestinationPath C:\ ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
     Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
@@ -47,9 +47,9 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
       ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
     Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
 
-ENV GIT_VERSION 2.18.0
+ENV GIT_VERSION 2.19.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/v${GIT_VERSION}.windows.1/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_SHA256 1dfd05de1320d57f448ed08a07c0b9de2de8976c83840f553440689b5db6a1cf
+ENV GIT_SHA256 f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
     Invoke-WebRequest -UseBasicParsing $env:GIT_DOWNLOAD_URL -OutFile git.zip; \

--- a/node/10/nano/Dockerfile.insider
+++ b/node/10/nano/Dockerfile.insider
@@ -23,7 +23,7 @@ RUN @( \
       gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
     }
  
-ENV NODE_VERSION 10.11.0
+ENV NODE_VERSION 10.12.0
  
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
     gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
@@ -34,7 +34,7 @@ RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f 
     Expand-Archive node.zip -DestinationPath C:\ ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
  
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
  
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
     Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
@@ -47,9 +47,9 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
       ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
     Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
  
-ENV GIT_VERSION 2.18.0
+ENV GIT_VERSION 2.19.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/v${GIT_VERSION}.windows.1/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_SHA256 1dfd05de1320d57f448ed08a07c0b9de2de8976c83840f553440689b5db6a1cf
+ENV GIT_SHA256 f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3
  
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
     Invoke-WebRequest -UseBasicParsing $env:GIT_DOWNLOAD_URL -OutFile git.zip; \

--- a/node/10/pure/Dockerfile
+++ b/node/10/pure/Dockerfile
@@ -23,7 +23,7 @@ RUN @( \
       gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
     }
 
-ENV NODE_VERSION 10.11.0
+ENV NODE_VERSION 10.12.0
 
 RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
     gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
@@ -34,7 +34,7 @@ RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f 
     Expand-Archive node.zip -DestinationPath C:\ ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
     Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \

--- a/node/10/pure/Dockerfile.insider
+++ b/node/10/pure/Dockerfile.insider
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/nanoserver-insider:10.0.17744.1001
-ADD https://nodejs.org/dist/v10.11.0/win-x64/node.exe C:/Windows/system32/node.exe
+ADD https://nodejs.org/dist/v10.12.0/win-x64/node.exe C:/Windows/system32/node.exe
 USER ContainerAdministrator
 CMD [ "node.exe" ]

--- a/node/build.ps1
+++ b/node/build.ps1
@@ -37,4 +37,4 @@ docker version
 #buildVersion "6.14.4" "6.14" "6"
 #buildVersion "8.11.4" "8.11" "8"
 
-buildVersion "10.11.0" "10.11" "10"
+buildVersion "10.12.0" "10.12" "10"

--- a/node/build.ps1
+++ b/node/build.ps1
@@ -21,17 +21,17 @@ copy $env:TEMP\docker\*.exe $env:ProgramFiles\docker
 Remove-Item $env:TEMP\docker.zip
 # $ErrorActionPreference = 'Stop'
 $env:PATH="c:\program files\docker;$env:PATH"
-#Write-Output "Stop com.docker.service"
-#Stop-Service com.docker.service
-#Write-Output "Stop docker"
-#Stop-Service docker
-#Write-Output "Unregister docker"
-#dockerd --unregister-service
-#Write-Output "Register docker"
-#dockerd --register-service
-#Write-Output "Start docker"
-#Start-Service docker
-#Write-Output "Running server docker engine"
+Write-Output "Stop docker"
+Stop-Service docker
+Write-Output "Stop com.docker.service"
+Stop-Service com.docker.service
+Write-Output "Unregister docker"
+dockerd --unregister-service
+Write-Output "Register docker"
+dockerd --register-service
+Write-Output "Start docker"
+Start-Service docker
+Write-Output "Running server docker engine"
 docker version
 
 #buildVersion "6.14.4" "6.14" "6"

--- a/node/build.ps1
+++ b/node/build.ps1
@@ -21,17 +21,17 @@ copy $env:TEMP\docker\*.exe $env:ProgramFiles\docker
 Remove-Item $env:TEMP\docker.zip
 # $ErrorActionPreference = 'Stop'
 $env:PATH="c:\program files\docker;$env:PATH"
-Write-Output "Stop com.docker.service"
-Stop-Service com.docker.service
-Write-Output "Stop docker"
-Stop-Service docker
-Write-Output "Unregister docker"
-dockerd --unregister-service
-Write-Output "Register docker"
-dockerd --register-service
-Write-Output "Start docker"
-Start-Service docker
-Write-Output "Running server docker engine"
+#Write-Output "Stop com.docker.service"
+#Stop-Service com.docker.service
+#Write-Output "Stop docker"
+#Stop-Service docker
+#Write-Output "Unregister docker"
+#dockerd --unregister-service
+#Write-Output "Register docker"
+#dockerd --register-service
+#Write-Output "Start docker"
+#Start-Service docker
+#Write-Output "Running server docker engine"
 docker version
 
 #buildVersion "6.14.4" "6.14" "6"

--- a/node/push.ps1
+++ b/node/push.ps1
@@ -24,6 +24,7 @@ function pushVersion($majorMinorPatch, $majorMinor, $major) {
 
   rebase-docker-image stefanscherer/node-windows:$majorMinorPatch-nanoserver-2016 -t stefanscherer/node-windows:$majorMinorPatch-nanoserver-1709 -b microsoft/nanoserver:1709
   rebase-docker-image stefanscherer/node-windows:$majorMinorPatch-nanoserver-2016 -t stefanscherer/node-windows:$majorMinorPatch-nanoserver-1803 -b microsoft/nanoserver:1803
+  rebase-docker-image stefanscherer/node-windows:$majorMinorPatch-nanoserver-2016 -t stefanscherer/node-windows:$majorMinorPatch-nanoserver-1809 -b stefanscherer/nanoserver:10.0.17763.1
 
   $coreManifest = @"
 image: stefanscherer/node-windows:{0}-windowsservercore
@@ -59,6 +60,11 @@ manifests:
     platform:
       architecture: amd64
       os: windows
+  -
+    image: stefanscherer/node-windows:{0}-nanoserver-1809
+    platform:
+      architecture: amd64
+      os: windows
 "@
 
   $nanoManifest -f $majorMinorPatch, $majorMinor, $major | Out-File nanoserver.yml -Encoding Ascii
@@ -84,6 +90,11 @@ manifests:
     platform:
       architecture: amd64
       os: windows
+  -
+    image: stefanscherer/node-windows:{0}-pure-1809
+    platform:
+      architecture: amd64
+      os: windows
 "@
 
   $pureManifest -f $majorMinorPatch, $majorMinor, $major | Out-File pure.yml -Encoding Ascii
@@ -96,4 +107,4 @@ choco install -y manifest-tool
 
 #pushVersion "6.14.4" "6.14" "6"
 #pushVersion "8.11.4" "8.11" "8"
-pushVersion "10.11.0" "10.11" "10"
+pushVersion "10.12.0" "10.12" "10"

--- a/node/test.ps1
+++ b/node/test.ps1
@@ -21,16 +21,16 @@ function testVersion($majorMinorPatch, $yarnVersion) {
   testCommand "node:$majorMinorPatch-windowsservercore" "node" "v$majorMinorPatch"
   testCommand "node:$majorMinorPatch-windowsservercore" "npm.cmd" ""
   testCommand "node:$majorMinorPatch-windowsservercore" "yarn.cmd" $yarnVersion
-  testCommand "node:$majorMinorPatch-windowsservercore" "git" "git version 2.18.0.windows.1"
+  testCommand "node:$majorMinorPatch-windowsservercore" "git" "git version 2.19.1.windows.1"
 
   testCommand "node:$majorMinorPatch-nanoserver" "node" "v$majorMinorPatch"
   testCommand "node:$majorMinorPatch-nanoserver" "npm.cmd" ""
   testCommand "node:$majorMinorPatch-nanoserver" "yarn.cmd" $yarnVersion
-  testCommand "node:$majorMinorPatch-nanoserver" "git" "git version 2.18.0.windows.1"
+  testCommand "node:$majorMinorPatch-nanoserver" "git" "git version 2.19.1.windows.1"
 
   testCommand "node:$majorMinorPatch-pure" "node" "v$majorMinorPatch"
 }
 
 #testVersion "6.14.4" "1.6.0"
 #testVersion "8.11.4" "1.6.0"
-testVersion "10.11.0" "1.9.4"
+testVersion "10.12.0" "1.10.1"


### PR DESCRIPTION
- Update Node.js 10.12.0
- Update Yarn 1.10.1
- Update Git 2.19.1 (as the release notes mentions it should include Git LFS)
- Add Windows Server 2019 variant to the manifest list
