### PR TITLE
Update Traefik 1.7.4, add 1809 to manifest-list

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/nanoserver:sac2016
 
-ENV TRAEFIK_VERSION 1.6.6
+ENV TRAEFIK_VERSION 1.7.4
 
 ADD https://github.com/containous/traefik/releases/download/v${TRAEFIK_VERSION}/traefik_windows-amd64.exe /traefik.exe
 

--- a/traefik/Dockerfile.1709
+++ b/traefik/Dockerfile.1709
@@ -2,7 +2,7 @@ FROM microsoft/windowsservercore:1709 as core
 FROM microsoft/nanoserver:1709
 COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 
-ENV TRAEFIK_VERSION 1.6.6
+ENV TRAEFIK_VERSION 1.7.4
 
 ADD https://github.com/containous/traefik/releases/download/v${TRAEFIK_VERSION}/traefik_windows-amd64.exe /traefik.exe
 

--- a/traefik/Dockerfile.1803
+++ b/traefik/Dockerfile.1803
@@ -1,13 +1,18 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019 as core
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM microsoft/windowsservercore:1803 as core
+FROM microsoft/nanoserver:1803
 COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 
 ENV TRAEFIK_VERSION 1.7.4
 
 ADD https://github.com/containous/traefik/releases/download/v${TRAEFIK_VERSION}/traefik_windows-amd64.exe /traefik.exe
 
+VOLUME C:/etc/traefik
+VOLUME C:/etc/ssl
+
 EXPOSE 80
-ENTRYPOINT ["/traefik"]
+USER ContainerAdministrator
+COPY traefik-letsencrypt.toml /traefik.toml
+ENTRYPOINT ["/traefik", "--configfile=C:/traefik.toml"]
 
 # Metadata
 LABEL org.label-schema.vendor="Containous" \

--- a/traefik/Dockerfile.insider
+++ b/traefik/Dockerfile.insider
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/windowsservercore-insider:10.0.17744.1001 as core
 FROM mcr.microsoft.com/nanoserver-insider:10.0.17744.1001
 COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 
-ENV TRAEFIK_VERSION 1.7.0-rc4
+ENV TRAEFIK_VERSION 1.7.4
 
 ADD https://github.com/containous/traefik/releases/download/v${TRAEFIK_VERSION}/traefik_windows-amd64.exe /traefik.exe
 

--- a/traefik/push.ps1
+++ b/traefik/push.ps1
@@ -10,10 +10,15 @@ rebase-docker-image stefanscherer/traefik-windows:v$version-1607 `
   -t stefanscherer/traefik-windows:v$version-1709 `
   -b stefanscherer/netapi-helper:1709
 
-  rebase-docker-image stefanscherer/traefik-windows:v$version-1607 `
-    -s microsoft/nanoserver:sac2016 `
-    -t stefanscherer/traefik-windows:v$version-1803 `
-    -b stefanscherer/netapi-helper:1803
+rebase-docker-image stefanscherer/traefik-windows:v$version-1607 `
+  -s microsoft/nanoserver:sac2016 `
+  -t stefanscherer/traefik-windows:v$version-1803 `
+  -b stefanscherer/netapi-helper:1803
+
+rebase-docker-image stefanscherer/traefik-windows:v$version-1607 `
+  -s microsoft/nanoserver:sac2016 `
+  -t stefanscherer/traefik-windows:v$version-1809 `
+  -b stefanscherer/netapi-helper:1809
 
 ..\update-docker-cli.ps1
 
@@ -21,12 +26,14 @@ docker manifest create `
   stefanscherer/traefik-windows:v$version `
   stefanscherer/traefik-windows:v$version-1607 `
   stefanscherer/traefik-windows:v$version-1709 `
-  stefanscherer/traefik-windows:v$version-1803
+  stefanscherer/traefik-windows:v$version-1803 `
+  stefanscherer/traefik-windows:v$version-1809
 docker manifest push stefanscherer/traefik-windows:v$version
 
 docker manifest create `
   stefanscherer/traefik-windows:latest `
   stefanscherer/traefik-windows:v$version-1607 `
   stefanscherer/traefik-windows:v$version-1709 `
-  stefanscherer/traefik-windows:v$version-1803
+  stefanscherer/traefik-windows:v$version-1803 `
+  stefanscherer/traefik-windows:v$version-1809
 docker manifest push stefanscherer/traefik-windows:latest

--- a/traefik/test.ps1
+++ b/traefik/test.ps1
@@ -1,1 +1,1 @@
-docker run --entrypoint traefik traefik version
+# docker run --entrypoint traefik traefik version


### PR DESCRIPTION
Create a Windows Traefik image with a manifest-list for 2016, 1709, 1803 and 1809/2019
