### PR TITLE
use MinGit-busybox flavor of git instead of MinGit one.

### DIFF
--- a/node/10/nano/Dockerfile
+++ b/node/10/nano/Dockerfile
@@ -47,9 +47,9 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
       ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
     Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
 
-ENV GIT_VERSION 2.19.1
-ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/v${GIT_VERSION}.windows.1/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_SHA256 f89e103a41bda8e12efeaab198a8c20bb4a84804683862da518ee2cb66a5a5b3
+ENV GIT_VERSION 2.20.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/v${GIT_VERSION}.windows.1/MinGit-${GIT_VERSION}-busybox-64-bit.zip
+ENV GIT_SHA256 9817ab455d9cbd0b09d8664b4afbe4bbf78d18b556b3541d09238501a749486c
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
     Invoke-WebRequest -UseBasicParsing $env:GIT_DOWNLOAD_URL -OutFile git.zip; \


### PR DESCRIPTION
The MinGit version of git seems to have incompatibilities with windows
since some commands as submodules are still implemented as Unix shell scripts:
https://github.com/git-for-windows/git/issues/1303#issuecomment-354977460

This solves bug  #372 on nanoserver 2016/1709/1803