### PR TITLE
Updated Traefik example to use named pipe

### DIFF
--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -1,15 +1,17 @@
-version: '2.1'
+version: '2.4'
 services:
   traefik:
     image: stefanscherer/traefik-windows
-    # we need the IP of the vEthernet (HNS Internal NIC)
-    command: --docker.endpoint=tcp://172.27.224.1:2375 --logLevel=DEBUG
+    command: --docker.endpoint=npipe:////./pipe/docker_engine --logLevel=DEBUG
     ports:
       - "8080:8080"
       - "443:443"
     volumes:
       - .:C:/etc/traefik
 #      - C:/Users/vagrant/.docker:C:/etc/ssl
+      - type: npipe
+        source: \\.\pipe\docker_engine
+        target: \\.\pipe\docker_engine
 
   whoami1:
     image: stefanscherer/whoami-windows


### PR DESCRIPTION
As Traefik looks now working with named pipes I think that it is better to use it on example configs.