### PR TITLE
Update Traefik docker-compose example

### DIFF
--- a/traefik/README.md
+++ b/traefik/README.md
@@ -5,7 +5,7 @@
 
 ## Example usage
 
-Start Træfɪk:
+Start Træfɪk on a Windows Server 2019 or Windows 10 1809.
 
 ```bash
 docker-compose up -d

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -5,55 +5,31 @@
 
 ## Example usage
 
-Grab a [sample configuration file](https://raw.githubusercontent.com/containous/traefik/master/traefik.sample.toml) and rename it to `traefik.toml`. Enable `docker` provider and web UI:
-
-```toml
-################################################################
-# Web configuration backend
-################################################################
-[web]
-address = ":8080"
-################################################################
-# Docker configuration backend
-################################################################
-[docker]
-domain = "docker.local"
-watch = true
-# increase docker api version to 1.24 with swarm-mode :-)
-swarmmode = true
-```
-
 Start Træfɪk:
 
 ```bash
-docker run -it -v C:$(pwd):C:/etc/traefik -v C:/Users/vagrant/.docker:C:/etc/ssl -p 8080:8080 -p 80:80 traefik --docker.endpoint=tcp://172.31.80.1:2375
-```
-
-Start a backend server, named `test`:
-
-```bash
-docker run -d --name test stefanscherer/whoami-windows
+docker-compose up -d
 ```
 
 And finally, you can access to your `whoami` server throught Træfɪk, on the domain name `{containerName}.{configuredDomain}`:
 
 ```bash
-curl --header 'Host: test.docker.local' 'http://localhost:80/'
-Hostname: 117c5530934d
-IP: 127.0.0.1
-IP: ::1
-IP: 172.17.0.3
-IP: fe80::42:acff:fe11:3
-GET / HTTP/1.1
-Host: 172.17.0.3:80
-User-Agent: curl/7.35.0
-Accept: */*
-Accept-Encoding: gzip
-X-Forwarded-For: 172.17.0.1
-X-Forwarded-Host: 172.17.0.3:80
-X-Forwarded-Proto: http
-X-Forwarded-Server: f2e05c433120
-
+PS C:\Users\stefan\code\dockerfiles-windows\traefik> docker-compose up -d
+Starting traefik_whoami2_1 ... done
+Starting traefik_whoami1_1 ... done
+Starting traefik_traefik_1 ... done
+PS C:\Users\stefan\code\dockerfiles-windows\traefik>
+PS C:\Users\stefan\code\dockerfiles-windows\traefik>
+PS C:\Users\stefan\code\dockerfiles-windows\traefik> docker ps
+CONTAINER ID        IMAGE                           COMMAND                  CREATED             STATUS              PORTS                                                              NAMES
+113ce8f5c552        stefanscherer/whoami            "\\http.exe"             32 minutes ago      Up 4 seconds        8080/tcp                                                           traefik_whoami1_1
+44c88c5055f0        stefanscherer/traefik-windows   "/traefik --configfi…"   32 minutes ago      Up 4 seconds        0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp, 0.0.0.0:8080->8080/tcp   traefik_traefik_1
+88673d7e3c03        stefanscherer/whoami            "\\http.exe"             32 minutes ago      Up 4 seconds        8080/tcp                                                           traefik_whoami2_1
+PS C:\Users\stefan\code\dockerfiles-windows\traefik> curl.exe -H Host:whoami.docker.local http://localhost
+I'm 113ce8f5c552 running on windows/amd64
+PS C:\Users\stefan\code\dockerfiles-windows\traefik> curl.exe -H Host:whoami.docker.local http://localhost
+I'm 88673d7e3c03 running on windows/amd64
+PS C:\Users\stefan\code\dockerfiles-windows\traefik>
 ```
 
 The web UI [http://localhost:8080](http://localhost:8080) will give you an overview of the frontends/backends and also a health dashboard.

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - "8080:8080"
       - "443:443"
+      - "80:80"
     volumes:
       - .:C:/etc/traefik
 #      - C:/Users/vagrant/.docker:C:/etc/ssl
@@ -14,18 +15,18 @@ services:
         target: \\.\pipe\docker_engine
 
   whoami1:
-    image: stefanscherer/whoami-windows
+    image: stefanscherer/whoami
     labels:
       - "traefik.backend=whoami"
-      - "traefik.frontend.entryPoints=https"
-      - "traefik.frontend.rule=Host:whoami.yourdomain.com"
+      - "traefik.frontend.entryPoints=http"
+      - "traefik.frontend.rule=Host:whoami.docker.local"
 
   whoami2:
-    image: stefanscherer/whoami-windows
+    image: stefanscherer/whoami
     labels:
       - "traefik.backend=whoami"
-      - "traefik.frontend.entryPoints=https"
-      - "traefik.frontend.rule=Host:whoami.yourdomain.com"
+      - "traefik.frontend.entryPoints=http"
+      - "traefik.frontend.rule=Host:whoami.docker.local"
 
 #  portainer:
 #    image: portainer/portainer

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -7,8 +7,10 @@ address = ":8080"
 # Docker configuration backend
 ################################################################
 [docker]
-domain = "yourdomain.com"
+domain = "docker.local"
 watch = true
+endpoint = "npipe:////./pipe/docker_engine"
+
 # Use Swarm Mode services as data provider
 #
 # Optional
@@ -16,93 +18,7 @@ watch = true
 #
 #swarmmode = true
 
-################################################################
-# Enable docker TLS connection
-# use -v path-on-host-to-tls-certs:C:\etc\ssl and the certs
-# will appear in drive S:
-################################################################
-#[docker.tls]
-#ca = "S:/ca.pem"
-#cert = "S:/cert.pem"
-#key = "S:/key.pem"
-
 # Sample entrypoint configuration when using ACME
 [entryPoints]
-  [entryPoints.https]
-  address = ":443"
-    [entryPoints.https.tls]
-
-# Enable ACME (Let's Encrypt): automatic SSL
-#
-# Optional
-#
-[acme]
-
-# Email address used for registration
-#
-# Required
-#
-email = "your@email.address"
-
-# File or key used for certificates storage.
-# WARNING, if you use Traefik in Docker, you have 2 options:
-#  - create a file on your host and mount it as a volume
-#      storageFile = "acme.json"
-#      $ docker run -v "/my/host/acme.json:acme.json" traefik
-#  - mount the folder containing the file as a volume
-#      storageFile = "/etc/traefik/acme/acme.json"
-#      $ docker run -v "/my/host/acme:/etc/traefik/acme" traefik
-#
-# Required
-#
-storage = "T:/acme.json" # or "traefik/acme/account" if using KV store
-
-# Entrypoint to proxy acme challenge to.
-# WARNING, must point to an entrypoint on port 443
-#
-# Required
-#
-entryPoint = "https"
-
-# Enable on demand certificate. This will request a certificate from Let's Encrypt during the first TLS handshake for a hostname that does not yet have a certificate.
-# WARNING, TLS handshakes will be slow when requesting a hostname certificate for the first time, this can leads to DoS attacks.
-# WARNING, Take note that Let's Encrypt have rate limiting: https://letsencrypt.org/docs/rate-limits
-#
-# Optional
-#
-# onDemand = true
-
-# Enable certificate generation on frontends Host rules. This will request a certificate from Let's Encrypt for each frontend with a Host rule.
-# For example, a rule Host:test1.traefik.io,test2.traefik.io will request a certificate with main domain test1.traefik.io and SAN test2.traefik.io.
-#
-# Optional
-#
-# OnHostRule = true
-
-# CA server to use
-# Uncomment the line to run on the staging let's encrypt server
-# Leave comment to go to prod
-#
-# Optional
-#
-# caServer = "https://acme-staging.api.letsencrypt.org/directory"
-
-# Domains list
-# You can provide SANs (alternative domains) to each main domain
-# All domains must have A/AAAA records pointing to Traefik
-# WARNING, Take note that Let's Encrypt have rate limiting: https://letsencrypt.org/docs/rate-limits
-# Each domain & SANs will lead to a certificate request.
-#
-# [[acme.domains]]
-#   main = "local1.com"
-#   sans = ["test1.local1.com", "test2.local1.com"]
-# [[acme.domains]]
-#   main = "local2.com"
-#   sans = ["test1.local2.com", "test2x.local2.com"]
-# [[acme.domains]]
-#   main = "local3.com"
-# [[acme.domains]]
-#   main = "local4.com"
-[[acme.domains]]
-   main = "yourdomain.com"
-   sans = ["whoami.yourdomain.com"] #, "portainer.yourdomain.com"]
+  [entryPoints.http]
+  address = ":80"


### PR DESCRIPTION
Update the docker-compose example for Traefik with a simple http frontend load-balancing two instances of whoami.

Follow-up of #379 
