### PR TITLE
Run traefik in process isolation mode

### DIFF
--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       - "8080:8080"
       - "443:443"
       - "80:80"
+    isolation: process # workaround for https://github.com/containous/traefik/issues/4409
     volumes:
       - .:C:/etc/traefik
-#      - C:/Users/vagrant/.docker:C:/etc/ssl
       - type: npipe
         source: \\.\pipe\docker_engine
         target: \\.\pipe\docker_engine


### PR DESCRIPTION
Run `traefik.exe` in process isolation mode to make the example docker-compose.yml work on Windows 10 1809 with Docker-Desktop 2.0.0.2 (Docker 18.09.1). This combination allows process isolation on Windows 10 as well.

This helps until https://github.com/containous/traefik/issues/4409 get fixed.

Fixes #383
