### PR TITLE
Also pull servercore image

### DIFF
--- a/netapi-helper/build.sh
+++ b/netapi-helper/build.sh
@@ -5,6 +5,7 @@ if [ "$1" == "" ]; then
   exit 1
 fi
 
+docker pull mcr.microsoft.com/windows/servercore:$1
 docker pull mcr.microsoft.com/windows/nanoserver:$1
 docker build -t stefanscherer/netapi-helper:$1 -f Dockerfile.$1 .
 docker push stefanscherer/netapi-helper:$1


### PR DESCRIPTION
When building a new version of the netapi-helper image, also pull the servercore image.