### PR TITLE
Testdrive 2019, build Traefik for 1803 and 1809

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Visual Studio 2017
+image: Windows Server 2019
 
 # Uncomment to debug via RDP
 # init:

--- a/traefik/build.ps1
+++ b/traefik/build.ps1
@@ -1,1 +1,2 @@
-docker build -t traefik .
+docker build -t traefik:1809 -f Dockerfile.1809 .
+docker build --isolation hyperv -t traefik:1803 -f Dockerfile.1803 .

--- a/traefik/push.ps1
+++ b/traefik/push.ps1
@@ -1,19 +1,9 @@
 $version=$(select-string -Path Dockerfile -Pattern "ENV TRAEFIK_VERSION").ToString().split()[-1]
 
-docker tag traefik stefanscherer/traefik-windows:v$version-1607-deprecated
-docker push stefanscherer/traefik-windows:v$version-1607-deprecated
-
-npm install -g rebase-docker-image
-
-rebase-docker-image stefanscherer/traefik-windows:v$version-1607-deprecated `
-  -s mcr.microsoft.com/windows/nanoserver:sac2016 `
-  -t stefanscherer/traefik-windows:v$version-1803 `
-  -b stefanscherer/netapi-helper:1803
-
-rebase-docker-image stefanscherer/traefik-windows:v$version-1607-deprecated `
-  -s mcr.microsoft.com/windows/nanoserver:sac2016 `
-  -t stefanscherer/traefik-windows:v$version-1809 `
-  -b stefanscherer/netapi-helper:1809
+docker tag traefik:1809 stefanscherer/traefik-windows:v$version-1809
+docker push stefanscherer/traefik-windows:v$version-1809
+docker tag traefik:1803 stefanscherer/traefik-windows:v$version-1803
+docker push stefanscherer/traefik-windows:v$version-1803
 
 ..\update-docker-cli.ps1
 


### PR DESCRIPTION
- Switch to private beta "Windows Server 2019"
- Adjust Traefik image build and manifest list without the rebase-docker-image tool.
