### PR TITLE
Switched to Nanoserver for smaller images

### DIFF
--- a/dockertls/Dockerfile
+++ b/dockertls/Dockerfile
@@ -7,11 +7,12 @@ ENV VERSION 2.5.5
 ENV LIBRESSLPATH C:\libressl
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-  Invoke-WebRequest "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$Env:VERSION-windows.zip" -OutFile libressl.zip -UseBasicParsing ; `
-  Expand-Archive libressl.zip -DestinationPath $Env:Temp ; `
+  Invoke-WebRequest "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$Env:VERSION-windows.zip" -OutFile $Env:Temp\libressl.zip -UseBasicParsing ; `
+  Expand-Archive $Env:Temp\libressl.zip -DestinationPath $Env:Temp ; `
   New-Item -ItemType Directory -Path $Env:LIBRESSLPATH ; `
   Copy-Item $Env:Temp\libressl-$Env:VERSION-windows\x64\* $Env:LIBRESSLPATH\. ; `
   Remove-Item $Env:LIBRESSLPATH\*.pdb ; `
+  Remove-Item $Env:Temp\libressl-$Env:VERSION-windows, $Env:Temp\libressl.zip -Force -Recurse ; `
   New-Item -ItemType Directory -Path $Env:LIBRESSLPATH\ssl 
 
 COPY openssl.cnf $LIBRESSLPATH/ssl/.

--- a/dockertls/Dockerfile
+++ b/dockertls/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM mcr.microsoft.com/powershell:nanoserver-1709
+FROM mcr.microsoft.com/powershell:nanoserver-1809
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV VERSION 2.5.5

--- a/dockertls/Dockerfile
+++ b/dockertls/Dockerfile
@@ -12,7 +12,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
   New-Item -ItemType Directory -Path $Env:LIBRESSLPATH ; `
   Copy-Item $Env:Temp\libressl-$Env:VERSION-windows\x64\* $Env:LIBRESSLPATH\. ; `
   Remove-Item $Env:LIBRESSLPATH\*.pdb ; `
-  Remove-Item $Env:Temp\libressl-$Env:VERSION-windows, libressl.zip -Force -Recurse ; `
   New-Item -ItemType Directory -Path $Env:LIBRESSLPATH\ssl 
 
 COPY openssl.cnf $LIBRESSLPATH/ssl/.

--- a/dockertls/Dockerfile
+++ b/dockertls/Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
-FROM mcr.microsoft.com/windows/servercore:ltsc2016
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+FROM mcr.microsoft.com/powershell:nanoserver-1709
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV VERSION 2.5.5
 
@@ -12,10 +12,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
   New-Item -ItemType Directory -Path $Env:LIBRESSLPATH ; `
   Copy-Item $Env:Temp\libressl-$Env:VERSION-windows\x64\* $Env:LIBRESSLPATH\. ; `
   Remove-Item $Env:LIBRESSLPATH\*.pdb ; `
-  $newPath = ('{0};{1}' -f $Env:LIBRESSLPATH, $Env:PATH); `
-  Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $newPath ; `
   Remove-Item $Env:Temp\libressl-$Env:VERSION-windows, libressl.zip -Force -Recurse ; `
-  New-Item -ItemType Directory -Path $Env:LIBRESSLPATH\ssl
+  New-Item -ItemType Directory -Path $Env:LIBRESSLPATH\ssl 
 
 COPY openssl.cnf $LIBRESSLPATH/ssl/.
 COPY generate-certs.ps1 generate-certs.ps1

--- a/dockertls/Dockerfile.1709
+++ b/dockertls/Dockerfile.1709
@@ -7,12 +7,12 @@ ENV VERSION 2.5.5
 ENV LIBRESSLPATH C:\libressl
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-  Invoke-WebRequest "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$Env:VERSION-windows.zip" -OutFile libressl.zip -UseBasicParsing ; `
-  Expand-Archive libressl.zip -DestinationPath $Env:Temp ; `
+  Invoke-WebRequest "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-$Env:VERSION-windows.zip" -OutFile $Env:Temp\libressl.zip -UseBasicParsing ; `
+  Expand-Archive $Env:Temp\libressl.zip -DestinationPath $Env:Temp ; `
   New-Item -ItemType Directory -Path $Env:LIBRESSLPATH ; `
   Copy-Item $Env:Temp\libressl-$Env:VERSION-windows\x64\* $Env:LIBRESSLPATH\. ; `
   Remove-Item $Env:LIBRESSLPATH\*.pdb ; `
-  Remove-Item $Env:Temp\libressl-$Env:VERSION-windows, libressl.zip -Force -Recurse ; `
+  Remove-Item $Env:Temp\libressl-$Env:VERSION-windows, $Env:Temp\libressl.zip -Force -Recurse ; `
   New-Item -ItemType Directory -Path $Env:LIBRESSLPATH\ssl 
 
 COPY openssl.cnf $LIBRESSLPATH/ssl/.

--- a/dockertls/Dockerfile.1709
+++ b/dockertls/Dockerfile.1709
@@ -1,5 +1,5 @@
 # escape=`
-FROM mcr.microsoft.com/powershell:nanoserver-1809
+FROM mcr.microsoft.com/powershell:nanoserver-1709
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV VERSION 2.5.5

--- a/dockertls/Dockerfile.1809
+++ b/dockertls/Dockerfile.1809
@@ -1,6 +1,6 @@
 # escape=`
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+FROM mcr.microsoft.com/powershell:nanoserver-1809
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV VERSION 2.5.5
 
@@ -12,10 +12,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
   New-Item -ItemType Directory -Path $Env:LIBRESSLPATH ; `
   Copy-Item $Env:Temp\libressl-$Env:VERSION-windows\x64\* $Env:LIBRESSLPATH\. ; `
   Remove-Item $Env:LIBRESSLPATH\*.pdb ; `
-  $newPath = ('{0};{1}' -f $Env:LIBRESSLPATH, $Env:PATH); `
-  Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $newPath ; `
   Remove-Item $Env:Temp\libressl-$Env:VERSION-windows, libressl.zip -Force -Recurse ; `
-  New-Item -ItemType Directory -Path $Env:LIBRESSLPATH\ssl
+  New-Item -ItemType Directory -Path $Env:LIBRESSLPATH\ssl 
 
 COPY openssl.cnf $LIBRESSLPATH/ssl/.
 COPY generate-certs.ps1 generate-certs.ps1

--- a/dockertls/README.md
+++ b/dockertls/README.md
@@ -18,7 +18,7 @@ docker run --rm `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
   -e SSL_EXPIRY_DAYS=730 `
   -v "$(pwd)\server:c:\programdata\docker" `
-  -v "$(pwd)\client\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+  -v "$(pwd)\client\.docker:c:\users\containeruser\.docker" stefanscherer/dockertls-windows
 dir server\certs.d
 dir server\config
 dir client\.docker
@@ -38,7 +38,7 @@ docker run --rm `
   -e SERVER_NAME=$(hostname) `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
   -v "c:\programdata\docker:c:\programdata\docker" `
-  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+  -v "$env:USERPROFILE\.docker:c:\users\containeruser\.docker" stefanscherer/dockertls-windows
 ```
 
 Afterwards restart the Docker service in an administrator SHELL
@@ -78,7 +78,7 @@ docker run --rm `
   -e MACHINE_HOME=/Users/you `
   -e MACHINE_IP=192.168.254.135 `
   -v "c:\programdata\docker:c:\programdata\docker" `
-  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+  -v "$env:USERPROFILE\.docker:c:\users\containeruser\.docker" stefanscherer/dockertls-windows
 ```
 
 ## Managing Multiple Hosts
@@ -96,7 +96,7 @@ docker run --rm `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
   -v "$env:SystemDrive\DockerSSLCARoot:c:\DockerSSLCARoot" `
   -v "$env:ALLUSERSPROFILE\docker:$env:ALLUSERSPROFILE\docker" `
-  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+  -v "$env:USERPROFILE\.docker:c:\users\containeruser\.docker" stefanscherer/dockertls-windows
 ```
 
 ### Subsequent Hosts
@@ -111,7 +111,7 @@ docker run --rm `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
   -v "$env:SystemDrive\DockerSSLCARoot:c:\DockerSSLCARoot" `
   -v "$env:ALLUSERSPROFILE\docker:$env:ALLUSERSPROFILE\docker" `
-  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+  -v "$env:USERPROFILE\.docker:c:\users\containeruser\.docker" stefanscherer/dockertls-windows
 ```
 
 ### Using an alternate Docker Data-Root directory in the daemon.json configuration file.
@@ -125,7 +125,7 @@ docker run --rm `
   -e DOCKER_DATA_ROOT=E:\ProgramData\Docker `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
   -v "E:\ProgramData\Docker:c:\programdata\docker" `
-  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+  -v "$env:USERPROFILE\.docker:c:\users\containeruser\.docker" stefanscherer/dockertls-windows
 ```
 
 ### Providing additional Subject Alternative Names the Docker TLS certificate will accept.
@@ -139,7 +139,7 @@ docker run --rm `
   -e "ALTERNATIVE_NAMES=$(HostName).$((Get-WmiObject win32_computersystem).Domain),manager.$((Get-WmiObject win32_computersystem).Domain)" `
   -e IP_ADDRESSES=127.0.0.1,192.168.254.135 `
   -v "c:\programdata\docker:c:\programdata\docker" `
-  -v "$env:USERPROFILE\.docker:c:\users\containeradministrator\.docker" stefanscherer/dockertls-windows
+  -v "$env:USERPROFILE\.docker:c:\users\containeruser\.docker" stefanscherer/dockertls-windows
 ```
 
 ## See also

--- a/dockertls/generate-certs.ps1
+++ b/dockertls/generate-certs.ps1
@@ -1,5 +1,8 @@
 $ErrorActionPreference = "Stop"
 
+$newPath = ('{0};{1}' -f $Env:LIBRESSLPATH, $Env:PATH) ; `
+[System.Environment]::SetEnvironmentVariable('Path', $newPath)
+
 $Global:DockerSSLCARoot = "c:\DockerSSLCARoot\"
 $Global:caPrivateKeyPassFile = ($Global:DockerSSLCARoot + "ca-key-pass.txt")
 $Global:caPrivateKeyPass = ""

--- a/dockertls/run.ps1
+++ b/dockertls/run.ps1
@@ -13,5 +13,5 @@ docker container run --rm `
   -e IP_ADDRESSES=$ips,$IPAddresses `
   -e ALTERNATIVE_NAMES=$AlternativeNames `
   -v "C:\ProgramData\docker:C:\ProgramData\docker" `
-  -v "$env:USERPROFILE\.docker:C:\Users\ContainerAdministrator\.docker" `
+  -v "$env:USERPROFILE\.docker:C:\Users\containeruser\.docker" `
   stefanscherer/dockertls-windows


### PR DESCRIPTION
To reduce overall container size by a factor of 10, I reconfigured the Dockerfile to pull the nanoserver build of PowerShell Core, updated the generate-certs.ps1 to add LibreSSL to the path at the start of the script (so we didn't hit compatibility issues w/ PowerSell 6.2) and updated the scripts & README to reflect the container running under the containeruser context instead of containeradministrator.

The Dockerfile uses powershell:nanoserver-1809 as the base image (needed for AppVeyor to succeed)