### PR TITLE
Check base image version

### DIFF
--- a/check-baseimage/Dockerfile
+++ b/check-baseimage/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
+COPY check-baseimage.ps1 check-baseimage.ps1
+RUN powershell -File check-baseimage.ps1

--- a/check-baseimage/README.md
+++ b/check-baseimage/README.md
@@ -1,0 +1,30 @@
+# Check base image for an update
+
+Once you push a Windows image it might get out of date.
+Let's hack a small script to check if the current image is out of date
+and there is a newer one in MCR, the Microsoft Container Registry.
+
+## Example
+
+```
+$ docker build -t stefanscherer/check-baseimage .
+Sending build context to Docker daemon  4.608kB
+Step 1/3 : FROM mcr.microsoft.com/windows/servercore:ltsc2016
+ ---> ea9f7aa13d03
+Step 2/3 : COPY check-baseimage.ps1 check-baseimage.ps1
+ ---> 719d742e96ec
+Step 3/3 : RUN powershell -File check-baseimage.ps1
+ ---> Running in 003723fac24c
+Base image Update Build Revision 2724, Hub Update Build Revision 3204
+C:\check-baseimage.ps1 : Your base image has update revision 2724, but should be
+updated to 3204!
+At C:\check-baseimage.ps1:15 char:3
++   Write-Error "Your base image has update revision $currUBR, but should be  ...
++   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorExcep
+   tion
+    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorExceptio
+   n,check-baseimage.ps1
+
+The command 'cmd /S /C powershell -File check-baseimage.ps1' returned a non-zero code: 1
+```

--- a/check-baseimage/check-baseimage.ps1
+++ b/check-baseimage/check-baseimage.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = 'Stop'
+
+# fetch the current version number from base image
+$current=(Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion")
+$currUBR=$current.UBR
+
+# fetch the maximum version number from MCR by filtering and sorting the JSON result
+$prefix="$($current.CurrentMajorVersionNumber).$($current.CurrentMinorVersionNumber).$($current.CurrentBuildNumber)."
+$json=$(Invoke-WebRequest -UseBasicParsing https://mcr.microsoft.com/v2/windows/servercore/tags/list | ConvertFrom-Json)
+$hubUBR=($json.tags | Where-Object -FilterScript { $_.StartsWith($prefix) -and $_ -Match "^\d+\.\d+\.\d+\.\d+$" } |%{[System.Version]$_}|sort)[-1].Revision
+
+Write-Output "Base image Update Build Revision $currUBR, Hub Update Build Revision $hubUBR"
+
+if ($currUBR -Lt $hubUBR) {
+  Write-Error "Your base image has update revision $currUBR, but should be updated to $hubUBR!"
+} else {
+  Write-Output "Your base image seems up to date."
+}


### PR DESCRIPTION
I started with this gist https://gist.github.com/StefanScherer/de02a89b4d6ea0e330678c222b4e8270 to check if a Windows Server is up to date.

Then I thought, ok that small script can also be used during a `docker build` or in an entrypoint during runtime of a Windows container to check if we're using an up to date base image.
