### PR TITLE
Run docker-compose in docker

### DIFF
--- a/compose/in-docker/Dockerfile
+++ b/compose/in-docker/Dockerfile
@@ -1,0 +1,18 @@
+ARG version=ltsc2019
+FROM mcr.microsoft.com/windows/servercore:$version
+
+ENV chocolateyUseWindowsCompression false
+
+RUN powershell -Command \
+    iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
+    choco feature disable --name showDownloadProgress
+
+RUN choco install -y docker-cli
+RUN choco install -y python -version 3.7.5
+RUN curl.exe -o get-pip.py https://bootstrap.pypa.io/get-pip.py
+RUN python get-pip.py
+RUN pip install docker-compose
+RUN curl.exe -Lo /Python37/lib/site-packages/docker/transport/npipesocket.py https://raw.githubusercontent.com/docker/docker-py/015f44d8f833df64e326d08f347b7f54e3c0d99f/docker/transport/npipesocket.py
+
+WORKDIR /test
+COPY docker-compose.yml docker-compose.yml

--- a/compose/in-docker/README.md
+++ b/compose/in-docker/README.md
@@ -1,0 +1,13 @@
+# Run docker-compose inside a Windows container
+
+## Build the test image
+
+```
+docker build -t compose-in-docker .
+```
+
+## Run docker-compose
+
+```
+docker run -v //./pipe/docker_engine://./pipe/docker_engine -it compose-in-docker docker-compose up
+```

--- a/compose/in-docker/docker-compose.yml
+++ b/compose/in-docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2.1'
+services:
+  whoami:
+    image: stefanscherer/whoami
+
+networks:
+  default:
+    external:
+      name: nat

--- a/compose/in-docker/run.sh
+++ b/compose/in-docker/run.sh
@@ -1,0 +1,1 @@
+docker run -v //./pipe/docker_engine://./pipe/docker_engine -it compose 


### PR DESCRIPTION
Run docker-compose in a windows container.

This PR is to test https://github.com/docker/docker-py/pull/2421 
It installs docker-compose with pip and replaces the npipesocket.py with the one from the pull request.

Without that change I get

```
$ docker run -v //./pipe/docker_engine://./pipe/docker_engine -it compose-in-docker docker-compose up

ERROR: Couldn't connect to Docker daemon. You might need to start Docker for Windows. 
```

With the change I get

```
$ docker run -v //./pipe/docker_engine://./pipe/docker_engine -it compose-in-docker docker-compose up

Creating test_whoami_1 ... done                                                                                
Attaching to test_whoami_1                                                                                     
whoami_1  | Listening on :8080                                                                                 
Gracefully stopping... (press Ctrl+C again to force) 
Stopping test_whoami_1 ... done                                                                                
```
