### PR TITLE
Add .NET Framework on Windows example

### DIFF
--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,0 +1,24 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows:1809
+
+USER ContainerAdministrator
+# Install .NET 4.8
+RUN curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
+    && .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+# Apply latest patch
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/05/windows10.0-kb4552930-x64-ndp48_3fb9f9a7b72e49707c8c49b4febc171411eca05f.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4552930-x64-ndp48.cab `
+    && rmdir /S /Q patch
+
+# ngen .NET Fx
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/dotnet/Dockerfile.orig
+++ b/dotnet/Dockerfile.orig
@@ -1,0 +1,23 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+# Install .NET 4.8
+RUN curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.microsoft.com/download/pr/7afca223-55d2-470a-8edc-6a1739ae3252/abd170b4b0ec15ad0222a809b761a036/ndp48-x86-x64-allos-enu.exe `
+    && .\dotnet-framework-installer.exe /q `
+    && del .\dotnet-framework-installer.exe `
+    && powershell Remove-Item -Force -Recurse ${Env:TEMP}\*
+
+# Apply latest patch
+RUN curl -fSLo patch.msu http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/05/windows10.0-kb4552930-x64-ndp48_3fb9f9a7b72e49707c8c49b4febc171411eca05f.msu `
+    && mkdir patch `
+    && expand patch.msu patch -F:* `
+    && del /F /Q patch.msu `
+    && DISM /Online /Quiet /Add-Package /PackagePath:C:\patch\windows10.0-kb4552930-x64-ndp48.cab `
+    && rmdir /S /Q patch
+
+# ngen .NET Fx
+ENV COMPLUS_NGenProtectedProcess_FeatureEnabled 0
+RUN \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen uninstall "Microsoft.Tpm.Commands, Version=10.0.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=amd64" `
+    && \Windows\Microsoft.NET\Framework64\v4.0.30319\ngen update `
+    && \Windows\Microsoft.NET\Framework\v4.0.30319\ngen update

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,0 +1,18 @@
+# .NET Framework on Windows image
+
+This Dockerfile builds a Windows image (the big one, not Windows Server Core) with .NET Framework 4.8.
+
+The Dockerfile is based on https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/runtime/windowsservercore-ltsc2019/Dockerfile
+with a few changes
+
+```diff
+3c3
+< FROM mcr.microsoft.com/windows/servercore:ltsc2019
+---
+> FROM mcr.microsoft.com/windows:1809
+4a5
+> USER ContainerAdministrator
+```
+
+The main difference is that the big Windows image has the default user ContainerUser instead of ContainerAdministrator and therefore does not have enough permission to install software.
+


### PR DESCRIPTION
# .NET Framework on Windows image

This Dockerfile builds a Windows image (the big one, not Windows Server Core) with .NET Framework 4.8.

The Dockerfile is based on https://github.com/microsoft/dotnet-framework-docker/blob/master/4.8/runtime/windowsservercore-ltsc2019/Dockerfile
with a few changes

```diff
3c3
< FROM mcr.microsoft.com/windows/servercore:ltsc2019
---
> FROM mcr.microsoft.com/windows:1809
4a5
> USER ContainerAdministrator
```

The main difference is that the big Windows image has the default user ContainerUser instead of ContainerAdministrator and therefore does not have enough permission to install software.

